### PR TITLE
Refactor: Improve active listeners check before unsubscription

### DIFF
--- a/src/lib/const/firebaseNode.ts
+++ b/src/lib/const/firebaseNode.ts
@@ -1,9 +1,0 @@
-const defaultListeners = {
-	value: {},
-	child_added: {},
-	child_changed: {},
-	child_moved: {},
-	child_removed: {},
-};
-
-export { defaultListeners };

--- a/src/lib/types/DatabaseNodeType.ts
+++ b/src/lib/types/DatabaseNodeType.ts
@@ -2,9 +2,9 @@ import { FirebaseApp } from "firebase/app";
 import { Auth } from "firebase/auth";
 import { Database } from "firebase/database";
 import admin from "firebase-admin";
-import { App } from "firebase-admin/app";
 import { Node } from "node-red";
 import DatabaseConfigType from "./DatabaseConfigType";
+import { FirebaseNodeType } from "./FirebaseNodeType";
 
 type DatabaseCredentials = {
 	apiKey: string;
@@ -15,23 +15,14 @@ type DatabaseCredentials = {
 	secret: string;
 };
 
-type SubscriptionsType = {
-	value: Record<string, number>;
-	child_added: Record<string, number>;
-	child_changed: Record<string, number>;
-	child_moved: Record<string, number>;
-	child_removed: Record<string, number>;
-};
-
 type DatabaseNodeType = Node & {
-	app?: FirebaseApp | App;
+	app?: FirebaseApp | admin.app.App;
 	auth?: Auth | admin.auth.Auth;
 	connected: boolean;
 	config: DatabaseConfigType;
 	credentials: DatabaseCredentials;
 	database?: Database | admin.database.Database;
-	nodes: Array<Node>;
-	subscribedListeners: SubscriptionsType;
+	nodes: Array<FirebaseNodeType>;
 };
 
 type JSONContentType = {

--- a/src/lib/types/FirebaseNodeType.ts
+++ b/src/lib/types/FirebaseNodeType.ts
@@ -1,7 +1,6 @@
 import admin from "firebase-admin";
-import { Node, NodeMessage, NodeMessageInFlow } from "node-red";
+import { Node, NodeDef, NodeMessage, NodeMessageInFlow } from "node-red";
 import { DatabaseNodeType } from "./DatabaseNodeType";
-import { NodeDef } from "node-red";
 
 export enum Query {
 	"set",
@@ -85,7 +84,6 @@ export interface FirebaseGetNodeType extends FirebaseNode {
 
 export interface FirebaseInNodeType extends FirebaseNode {
 	config: FirebaseInConfigType;
-	subscribed: boolean;
 }
 
 export interface FirebaseOutNodeType extends FirebaseNode {

--- a/src/nodes/database.ts
+++ b/src/nodes/database.ts
@@ -1,5 +1,4 @@
 import { NodeAPI } from "node-red";
-import { defaultListeners } from "../lib/const/firebaseNode";
 import FirebaseDatabase from "../lib/databaseNode";
 import DatabaseConfigType from "../lib/types/DatabaseConfigType";
 import { DatabaseNodeType } from "../lib/types/DatabaseNodeType";
@@ -11,7 +10,6 @@ module.exports = function (RED: NodeAPI) {
 
 		self.connected = false;
 		self.config = config;
-		self.subscribedListeners = defaultListeners;
 		self.nodes = [];
 
 		const database = new FirebaseDatabase(self);

--- a/src/nodes/firebase-in.ts
+++ b/src/nodes/firebase-in.ts
@@ -9,7 +9,6 @@ module.exports = function (RED: NodeAPI) {
 		const self = this;
 
 		self.config = config;
-		self.subscribed = false;
 		self.database = RED.nodes.getNode(config.database) as DatabaseNodeType | null;
 
 		if (!self.database) {

--- a/test/firebase-in_spec.js
+++ b/test/firebase-in_spec.js
@@ -144,23 +144,5 @@ describe("Firebase IN Node", function () {
 					.catch((error) => done(error));
 			});
 		});
-
-		it("should do unSubscription Query", function (done) {
-			const newFlow = [{ id: "firebase", type: "firebase-in", database: "database", path: "test" }, ...flow];
-
-			helper.load([firebase, database], newFlow, function () {
-				const n1 = helper.getNode("firebase");
-				n1.database.subscribedListeners.value["test"] = 1;
-				n1.subscribed = true;
-
-				n1.close(true)
-					.then(() => {
-						const object = n1.database.subscribedListeners.value;
-						Object.values(object).should.have.length(0);
-						done();
-					})
-					.catch((error) => done(error));
-			});
-		});
 	});
 });


### PR DESCRIPTION
Prevents the unsubscription of a listener if it is still used in one or more other nodes.
Check nodes array instead of node count for each listener.