### PR TITLE
Feature: `On Disconnect` Node

### DIFF
--- a/build/nodes/locales/en-US/on-disconnect.html
+++ b/build/nodes/locales/en-US/on-disconnect.html
@@ -1,0 +1,62 @@
+<!--
+  Copyright 2022-2023 Gauthier Dandele
+
+  Licensed under the MIT License,
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://opensource.org/licenses/MIT.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="on-disconnect">
+	<p>Connects to a Firebase Realtime Database and add/modify data to database when the client disconnects.</p>
+	<h3>Inputs</h3>
+	<dl class="message-properties">
+		<dt>payload<span class="property-type">string | boolean | number | array | object | null</span></dt>
+ 		<dd>the data that will be sent to the database.</dd>
+ 		<dt class="optional">method<span class="property-type">string</span></dt>
+ 		<dd>the type of query to apply to the data (set, cancel, update, remove or setWithPriority).</dd>
+ 		<dt class="optional">priority<span class="property-type">number</span></dt>
+ 		<dd>the priority to apply to the data. By default 1.</dd>
+ 		<dt class="optional">topic<span class="property-type">string</span></dt>
+ 		<dd>the path of the data to add/modify. By default 'topic'.</dd>
+	</dl>
+	<h3>Outputs</h3>
+	<dl class="message-properties">
+		<dt>payload<span class="property-type">number</span></dt>
+		<dd>contains the current time (timestamp).</dd>
+		<dt>event<span class="property-type">string</span></dt>
+		<dd>the triggered event (<code>connected</code> or <code>disconnect</code>).</dd>
+		<dt>topic<span class="property-type">string</span></dt>
+		<dd>the database URL.</dd>
+	</dl>
+	<h3>Details</h3>
+	<p>
+		This node allows you to write or clear data when your client disconnects from the Database server.
+		These updates occur whether your client disconnects cleanly or not, so you can rely on them to clean up data even if a connection is dropped or a client crashes.
+	</p>
+	<b>Note that <code>onDisconnect</code> operations are only triggered once!</b>
+	<p></p>
+	<p>Below is a list of query types with their description:</p>
+	<ul>
+		<li><strong>Set</strong>: overwrite data on every write.</li>
+		<li><strong>Cancel</strong>: Cancels all previously queued <code>onDisconnect</code> set or update events for this location and all children.</li>
+		<li><strong>Update</strong>: update values for each matching key in the database.</li>
+		<li><strong>Remove</strong>: the data at the Firebase reference and all child data is removed.</li>
+		<li><strong>Set With Priority</strong>: the priority and overwrite data.</li>
+	</ul>
+	<p>
+		The <strong>Path</strong> determines where the data will be written. It can be defined in the node or dynamically
+		with the <code>msg.topic</code> property
+	</p>
+	<p>
+		Learn more about how to use this node
+		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/on-disconnect">here</a>.
+	</p>
+</script>

--- a/build/nodes/locales/en-US/on-disconnect.json
+++ b/build/nodes/locales/en-US/on-disconnect.json
@@ -8,7 +8,8 @@
       "name": "Name"
     },
     "queryType": {
-      "none": "- use msg.method -",
+      "msg": "- use msg.method -",
+      "none": "NONE",
       "cancel": "CANCEL",
       "set": "SET",
       "update": "UPDATE",

--- a/build/nodes/locales/en-US/on-disconnect.json
+++ b/build/nodes/locales/en-US/on-disconnect.json
@@ -1,0 +1,26 @@
+{
+  "on-disconnect": {
+    "label": {
+      "database": "Database",
+      "query": "Method",
+      "path": "Path",
+      "sendMsgEvent": "Send Msg",
+      "name": "Name"
+    },
+    "queryType": {
+      "none": "- use msg.method -",
+      "cancel": "CANCEL",
+      "set": "SET",
+      "update": "UPDATE",
+      "remove": "REMOVE",
+      "setWithPriority": "SET WITH PRIORITY"
+    },
+    "sendMsgEvent": {
+      "onConnected": "On Connected",
+      "onDisconnect": "On Disconnect"
+    },
+    "placeholder": {
+      "name": "Name"
+    }
+  }
+}

--- a/build/nodes/locales/fr/on-disconnect.html
+++ b/build/nodes/locales/fr/on-disconnect.html
@@ -1,0 +1,62 @@
+<!--
+  Copyright 2022-2023 Gauthier Dandele
+
+  Licensed under the MIT License,
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://opensource.org/licenses/MIT.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="on-disconnect">
+	<p>Se connecte à une base de données Firebase Realtime et ajoute/modifie des données à/de la base de données lorsque le client se déconnecte.</p>
+	<h3>Entrées</h3>
+	<dl class="message-properties">
+		<dt>payload<span class="property-type">chaîne | booléen | nombre | tableau | objet | nul</span></dt>
+ 		<dd>les données qui seront envoyées à la base de données.</dd>
+ 		<dt class="optional">method<span class="property-type">chaîne de caractères</span></dt>
+ 		<dd>le type de requête à appliquer aux données (définir, annuler, mettre à jour, supprimer ou définir avec priorité).</dd>
+ 		<dt class="optional">priority<span class="property-type">nombre</span></dt>
+ 		<dd>la priorité à appliquer aux données. Par défaut 1.</dd>
+ 		<dt class="optional">topic<span class="property-type">chaîne de caractères</span></dt>
+ 		<dd>le chemin des données à ajouter/modifier. Par défaut 'topic'.</dd>
+	</dl>
+	<h3>Sorties</h3>
+	<dl class="message-properties">
+		<dt>payload<span class="property-type">nombre</span></dt>
+ 		<dd>contient l'heure actuel (timestamp).</dd>
+ 		<dt>event<span class="property-type">chaîne de caractères</span></dt>
+ 		<dd>l'événement déclenché (<code>connected</code> ou <code>disconnect</code>).</dd>
+ 		<dt>topic<span class="property-type">chaîne de caractères</span></dt>
+ 		<dd>l'URL de la base de données.</dd>
+	</dl>
+	<h3>Détails</h3>
+	<p>
+		Ce noeud vous permet d'écrire ou d'effacer des données lorsque votre client se déconnecte du serveur de base de données.
+		Ces mises à jour se produisent que votre client se déconnecte proprement ou non, vous pouvez donc compter sur elles pour nettoyer les données même si une connexion est interrompue ou si un client tombe en panne.
+	</p>
+	<b>Notez que les opérations <code>onDisconnect</code> ne sont déclenchées qu'une seule fois !</b>
+	<p></p>
+	<p>Ci-dessous une liste des types de requêtes avec leur description :</p>
+	<ul>
+		<li><strong>Définir</strong> : écrase les données à chaque écriture.</li>
+		<li><strong>Annuler</strong> : annule tous les événements de définition ou de mise à jour <code>onDisconnect</code> précédemment mis en file d'attente pour cet emplacement et tous les enfants.</li>
+		<li><strong>Mettre à jour</strong> : mets à jour les valeurs pour chaque clé correspondante dans la base de données.</li>
+		<li><strong>Supprimer</strong> : les données de la référence Firebase et toutes les données enfants sont supprimées.</li>
+		<li><strong>Définir avec priorité</strong> : écrase les données et défini la priorité.</li>
+	</ul>
+	<p>
+		Le <strong>Chemin</strong> détermine où les données seront écrites. Il peut être défini dans le noeud ou dynamiquement
+		avec la propriété <code>msg.topic</code>
+	</p>
+	<p>
+		En savoir plus sur l'utilisation de ce noeud
+		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/on-disconnect">ici</a>.
+	</p>
+</script>

--- a/build/nodes/locales/fr/on-disconnect.json
+++ b/build/nodes/locales/fr/on-disconnect.json
@@ -8,7 +8,8 @@
       "name": "Nom"
     },
     "queryType": {
-      "none": "- utiliser msg.method -",
+      "msg": "- utiliser msg.method -",
+      "none": "Aucune",
       "cancel": "Annuler",
       "set": "Définir",
       "update": "Mettre à jour",

--- a/build/nodes/locales/fr/on-disconnect.json
+++ b/build/nodes/locales/fr/on-disconnect.json
@@ -1,0 +1,26 @@
+{
+  "on-disconnect": {
+    "label": {
+      "database": "Database",
+      "query": "Méthode",
+      "path": "Chemin",
+      "sendMsgEvent": "Envoie Msg",
+      "name": "Nom"
+    },
+    "queryType": {
+      "none": "- utiliser msg.method -",
+      "cancel": "Annuler",
+      "set": "Définir",
+      "update": "Mettre à jour",
+      "remove": "Supprimer",
+      "setWithPriority": "Définir avec priorité"
+    },
+    "sendMsgEvent": {
+      "onConnected": "À la connexion établie",
+      "onDisconnect": "À la déconnexion"
+    },
+    "placeholder": {
+      "name": "Nom"
+    }
+  }
+}

--- a/build/nodes/on-disconnect.html
+++ b/build/nodes/on-disconnect.html
@@ -26,11 +26,12 @@
 			defaults: {
 				name: { value: "" },
 				database: { value: "", type: "database-config" },
+				inputs: { value: 1 },
 				outputs: { value: 0 },
 				path: { value: "topic" },
 				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
 				sendMsgEvent: { value: "" },
-				queryType: { value: "none", validate: RED.validators.regex(/^(none|cancel|set|update|remove|setWithPriority)$/) },
+				queryType: { value: "msg", validate: RED.validators.regex(/^(msg|none|cancel|set|update|remove|setWithPriority)$/) },
 			},
 			inputs: 1,
 			outputs: 0,
@@ -41,10 +42,10 @@
 			icon: "firebase.png",
 			paletteLabel: "On Disconnect",
 			label: function () {
-				const query = this.queryType !== "none" ? this.queryType.toUpperCase() : "";
+				const query = this.queryType?.match(/^(msg|none)$/) ? "" : this.queryType?.toUpperCase() || "";
 				const path = this.pathType === "msg" ? "" : this.path;
 				const name = query.concat(query ? " " : "", path);
-				return this.name || name || "On Disconnect";
+				return this.name || name || this.sendMsgEvent || "On Disconnect";
 			},
 			labelStyle: function () {
 				return this.name ? "node_label_italic" : "";
@@ -63,20 +64,13 @@
 					sendMsgEventOption = sendMsgEventOption.map((fieldName) => ({ value: fieldName, label: node._(`on-disconnect.sendMsgEvent.${fieldName}`) }));
 				}
 
-				$("#node-input-sendMsgEvent").typedInput({ type: "event", types: [{ value: "event", multiple: true, options: sendMsgEventOption }] });
+				$("#node-input-sendMsgEvent").typedInput({ type: "event", types: [{ value: "event", multiple: true, options: sendMsgEventOption, validate: RED.validators.regex(/^(onConnected,)?(|onConnected|onDisconnect)$/) }] });
 
-				queryType.on("change", () => {
-					switch (queryType.val()) {
-						case "setWithPriority":
-							$(".form-row-priority").show();
-							break;
-						default:
-							$(".form-row-priority").hide();
-							break;
-					}
-				});
+				queryType.on("change", () => queryType.val() === "none" ? $(".form-row-path").hide() : $(".form-row-path").show());
 			},
 			oneditsave: function () {
+				const inputs = $("#node-input-queryType").val() === "none" ? 0 : 1;
+				$("#node-input-inputs").val(inputs);
 				const value = $("#node-input-sendMsgEvent").typedInput("value");
 				const array = !value ? [] : value.split(",");
 				$("#node-input-outputs").val(array.length);
@@ -99,7 +93,9 @@
 
 	<div class="form-row">
 		<label for="node-input-queryType"><i class="fa fa-bars"></i> <span data-i18n="on-disconnect.label.query"></span></label>
+		<input type="hidden" id="node-input-inputs" />
 		<select id="node-input-queryType" style="width:70%;">
+			<option value="msg" data-i18n="on-disconnect.queryType.msg"></option>
 			<option value="none" data-i18n="on-disconnect.queryType.none"></option>
 			<option value="cancel" data-i18n="on-disconnect.queryType.cancel"></option>
 			<option value="set" data-i18n="on-disconnect.queryType.set"></option>
@@ -109,7 +105,7 @@
 		</select>
 	</div>
 
-	<div class="form-row">
+	<div class="form-row form-row-path">
 		<label for="node-input-path"><i class="fa fa-sitemap"></i> <span data-i18n="on-disconnect.label.path"></span></label>
 		<input type="text" id="node-input-path" style="width:70%;" />
 		<input type="hidden" id="node-input-pathType" />

--- a/build/nodes/on-disconnect.html
+++ b/build/nodes/on-disconnect.html
@@ -1,0 +1,128 @@
+<!--
+  Copyright 2022-2023 Gauthier Dandele
+
+  Licensed under the MIT License,
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://opensource.org/licenses/MIT.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/javascript">
+	(function () {
+		let sendMsgEventOption = ["onConnected", "onDisconnect"];
+		let translationInitialized = false;
+
+		RED.nodes.registerType("on-disconnect", {
+			align: "left",
+			category: "Firebase",
+			color: "#e2a12b",
+			defaults: {
+				name: { value: "" },
+				database: { value: "", type: "database-config" },
+				outputs: { value: 0 },
+				path: { value: "topic" },
+				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
+				sendMsgEvent: { value: "" },
+				queryType: { value: "none", validate: RED.validators.regex(/^(none|cancel|set|update|remove|setWithPriority)$/) },
+			},
+			inputs: 1,
+			outputs: 0,
+			outputLabels: function (index) {
+				const labelArray = !this.sendMsgEvent ? [""] : this.sendMsgEvent.split(",");
+				return labelArray[index];
+			},
+			icon: "firebase.png",
+			paletteLabel: "On Disconnect",
+			label: function () {
+				const query = this.queryType !== "none" ? this.queryType.toUpperCase() : "";
+				const path = this.pathType === "msg" ? "" : this.path;
+				const name = query.concat(query ? " " : "", path);
+				return this.name || name || "On Disconnect";
+			},
+			labelStyle: function () {
+				return this.name ? "node_label_italic" : "";
+			},
+			oneditprepare: function () {
+				const queryType = $("#node-input-queryType");
+				const node = this;
+
+				$("#node-input-path").typedInput({
+					typeField: $("#node-input-pathType"),
+					types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
+				});
+
+				if (!translationInitialized) {
+					translationInitialized = true;
+					sendMsgEventOption = sendMsgEventOption.map((fieldName) => ({ value: fieldName, label: node._(`on-disconnect.sendMsgEvent.${fieldName}`) }));
+				}
+
+				$("#node-input-sendMsgEvent").typedInput({ type: "event", types: [{ value: "event", multiple: true, options: sendMsgEventOption }] });
+
+				queryType.on("change", () => {
+					switch (queryType.val()) {
+						case "setWithPriority":
+							$(".form-row-priority").show();
+							break;
+						default:
+							$(".form-row-priority").hide();
+							break;
+					}
+				});
+			},
+			oneditsave: function () {
+				const value = $("#node-input-sendMsgEvent").typedInput("value");
+				const array = !value ? [] : value.split(",");
+				$("#node-input-outputs").val(array.length);
+			}
+		});
+
+		function isPathValid(x) {
+			if (!x || typeof x !== "string") return false;
+			if (x.match(/^\s|[.#$\[\]]/g)) return false;
+			return true;
+		}
+	})();
+</script>
+
+<script type="text/html" data-template-name="on-disconnect">
+	<div class="form-row">
+		<label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="on-disconnect.label.database"></span></label>
+		<input type="text" id="node-input-database" style="width:70%;" />
+	</div>
+
+	<div class="form-row">
+		<label for="node-input-queryType"><i class="fa fa-bars"></i> <span data-i18n="on-disconnect.label.query"></span></label>
+		<select id="node-input-queryType" style="width:70%;">
+			<option value="none" data-i18n="on-disconnect.queryType.none"></option>
+			<option value="cancel" data-i18n="on-disconnect.queryType.cancel"></option>
+			<option value="set" data-i18n="on-disconnect.queryType.set"></option>
+			<option value="update" data-i18n="on-disconnect.queryType.update"></option>
+			<option value="remove" data-i18n="on-disconnect.queryType.remove"></option>
+			<option value="setWithPriority" data-i18n="on-disconnect.queryType.setWithPriority"></option>
+		</select>
+	</div>
+
+	<div class="form-row">
+		<label for="node-input-path"><i class="fa fa-sitemap"></i> <span data-i18n="on-disconnect.label.path"></span></label>
+		<input type="text" id="node-input-path" style="width:70%;" />
+		<input type="hidden" id="node-input-pathType" />
+	</div>
+
+	<div class="form-row">
+		<label for="node-input-sendMsgEvent"><i class="fa fa-sign-out"></i> <span data-i18n="on-disconnect.label.sendMsgEvent"></span></label>
+		<input type="text" id="node-input-sendMsgEvent" style="width:70%;" />
+		<input type="hidden" id="node-input-outputs" />
+	</div>
+
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="on-disconnect.label.name"></span></label>
+		<input type="text" id="node-input-name" data-i18n="[placeholder]on-disconnect.placeholder.name" />
+	</div>
+</script>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "database-config": "build/nodes/database.js",
       "firebase-in": "build/nodes/firebase-in.js",
       "firebase-get": "build/nodes/firebase-get.js",
-      "firebase-out": "build/nodes/firebase-out.js"
+      "firebase-out": "build/nodes/firebase-out.js",
+      "on-disconnect": "build/nodes/on-disconnect.js"
     },
     "version": ">=1.3.7"
   },

--- a/src/lib/databaseNode.ts
+++ b/src/lib/databaseNode.ts
@@ -234,9 +234,11 @@ export default class FirebaseDatabase {
 					}
 
 					this.setNodesConnected();
+					this.node.RED.events.emit("Firebase:connected");
 					this.node.log(`Connected to Firebase database: ${this.node.app?.options.databaseURL}`);
 				} else {
 					this.setNodesConnecting();
+					this.node.RED.events.emit("Firebase:disconnect");
 					// Based on maximum time for Firebase admin
 					this.timeoutID = setTimeout(() => this.setNodesDisconnected(), 30000);
 					this.node.log(`Connecting to Firebase database: ${this.node.app?.options.databaseURL}`);

--- a/src/lib/onDisconnectNode.ts
+++ b/src/lib/onDisconnectNode.ts
@@ -24,7 +24,7 @@ import { printEnumKeys } from "./utils";
 /**
  * OnDisconnect Class
  *
- * This class is used to define the query to run when the client disconnects from the database.
+ * This class is used to define the query to run **when the client disconnects** from the database.
  *
  * It is used to set, set with priority, update, remove, or cancel data when the client disconnects from the database.
  *
@@ -74,6 +74,7 @@ export class OnDisconnect extends Firebase {
 		throw new Error(`msg.method must be one of ${printEnumKeys(Query)}.`);
 	}
 
+	/** @override */
 	public override deregisterNode(removed: boolean, done: (error?: unknown) => void) {
 		try {
 			const nodes = this.node.database?.nodes;
@@ -103,14 +104,17 @@ export class OnDisconnect extends Firebase {
 	 * @returns The path checked to the database
 	 */
 	private getPath(msg: InputMessageType) {
+		const pathSetted = this.node.config.path;
 		let path;
+
+		if (pathSetted === undefined) throw new Error("The 'Path' field is undefined, please re-configure this node.");
 
 		switch (this.node.config.pathType) {
 			case "msg":
-				path = msg[this.node.config.path as keyof typeof msg];
+				path = this.node.RED.util.getMessageProperty(msg, pathSetted);
 				break;
 			case "str":
-				path = this.node.config.path;
+				path = pathSetted;
 				break;
 			default:
 				throw new Error("pathType should be 'msg' or 'str', please re-configure this node.");
@@ -120,7 +124,7 @@ export class OnDisconnect extends Firebase {
 	}
 
 	/**
-	 * Gets the priority from the node or message. Calls `checkPriority` to check the priority.
+	 * Gets the priority from the message. Calls `checkPriority` to check the priority.
 	 * @param msg The message received
 	 * @returns The priority checked
 	 */

--- a/src/lib/onDisconnectNode.ts
+++ b/src/lib/onDisconnectNode.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2022-2023 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { onDisconnect, ref } from "firebase/database";
+import { Firebase } from "./firebaseNode";
+import { InputMessageType } from "./types/FirebaseNodeType";
+import { Query } from "./types/OnDisconnectConfigType";
+import { OnDisconnectNodeType, OutputMessageType, SendMsgEvent } from "./types/OnDisconnectNodeType";
+import { printEnumKeys } from "./utils";
+
+/**
+ * OnDisconnect Class
+ */
+export class OnDisconnect extends Firebase {
+	constructor(protected node: OnDisconnectNodeType) {
+		super(node);
+	}
+
+	private sendMsgOnConnected = () => this.sendMsgOnEvent("connected");
+
+	private sendMsgOnDisconnect = () => this.sendMsgOnEvent("disconnect");
+
+	/**
+	 * Checks if the priority is valid otherwise throws an error.
+	 * @param priority The priority to be checked
+	 * @returns The priority checked
+	 */
+	private checkPriority(priority: unknown) {
+		if (priority === undefined) throw new Error("msg.priority do not exist!");
+		if (typeof priority === "number") return priority;
+		if (typeof priority === "string" && Number.isInteger(parseInt(priority))) return parseInt(priority);
+		throw new Error("msg.priority must be a number!");
+	}
+
+	/**
+	 * Checks if the query is valid otherwise throws an error.
+	 * @param method The query to be checked
+	 * @returns The query checked
+	 */
+	private checkQuery(method: unknown) {
+		if (method === undefined) throw new Error("msg.method do not exist!");
+		if (typeof method !== "string") throw new Error("msg.method must be a string!");
+		if (method in Query) return method as keyof typeof Query;
+		throw new Error(`msg.method must be one of ${printEnumKeys(Query)}.`);
+	}
+
+	public override deregisterNode(removed: boolean, done: (error?: unknown) => void) {
+		try {
+			const nodes = this.node.database?.nodes;
+
+			if (this.signedInCallback) this.node.RED.events.removeListener("Firebase:signedIn", this.signedInCallback);
+			this.node.RED.events.removeListener("Firebase:connected", this.sendMsgOnConnected);
+			this.node.RED.events.removeListener("Firebase:disconnect", this.sendMsgOnDisconnect);
+
+			if (!nodes) return done();
+
+			nodes.forEach((node) => {
+				if (node.id !== this.node.id) return;
+				nodes.splice(nodes.indexOf(node), 1);
+			});
+
+			this.node.database?.destroyUnusedConnection(removed);
+
+			done();
+		} catch (error) {
+			done(error);
+		}
+	}
+
+	/**
+	 * Gets the path to the database from the node or message. Calls `checkPath` to check the path.
+	 * @param msg The message received
+	 * @returns The path checked to the database
+	 */
+	private getPath(msg: InputMessageType) {
+		let path;
+
+		switch (this.node.config.pathType) {
+			case "msg":
+				path = msg[this.node.config.path as keyof typeof msg];
+				break;
+			case "str":
+				path = this.node.config.path;
+				break;
+			default:
+				throw new Error("pathType should be 'msg' or 'str', please re-configure this node.");
+		}
+
+		return this.checkPath(path, false);
+	}
+
+	/**
+	 * Gets the priority from the node or message. Calls `checkPriority` to check the priority.
+	 * @param msg The message received
+	 * @returns The priority checked
+	 */
+	private getPriority(msg: InputMessageType) {
+		return this.checkPriority(msg.priority);
+	}
+
+	/**
+	 * Gets the query from the node or message. Calls `checkQuery` to check the query.
+	 * @param msg The message received
+	 * @returns The query checked
+	 */
+	private getQuery(msg: InputMessageType) {
+		const query = this.node.config.queryType === "none" ? msg.method : this.node.config.queryType;
+		return this.checkQuery(query);
+	}
+
+	private sendMsgOnEvent(event: SendMsgEvent) {
+		try {
+			if (!this.node.database) return;
+
+			const msg2Send: OutputMessageType = {
+				payload: Date.now(),
+				event: event,
+				topic: this.node.database.app?.options.databaseURL || "",
+			};
+
+			this.node.send(msg2Send);
+		} catch (error) {
+			this.node.error(error);
+		}
+	}
+
+	private setNodeQueryDone() {
+		this.node.status({ fill: "blue", shape: "dot", text: "Query Done!" });
+		setTimeout(() => this.setNodeStatus(), 500);
+	}
+
+	public async setOnDisconnectQuery(msg: InputMessageType) {
+		const path = this.getPath(msg);
+		const query = this.getQuery(msg);
+
+		if (!this.db) return;
+
+		if (!(await this.isUserSignedIn())) return Promise.resolve();
+
+		const databaseRef = this.isAdmin(this.db)
+			? this.db.ref().child(path).onDisconnect()
+			: onDisconnect(ref(this.db, path));
+
+		switch (query) {
+			case "cancel":
+			case "remove":
+				await databaseRef[query]();
+				break;
+			case "set":
+				await databaseRef[query](msg.payload);
+				break;
+			case "update":
+				if (msg.payload && typeof msg.payload === "object") {
+					await databaseRef[query](msg.payload);
+					break;
+				}
+
+				throw new Error("msg.payload must be an object with 'update' query.");
+			case "setWithPriority":
+				await databaseRef[query](msg.payload, this.getPriority(msg));
+				break;
+		}
+
+		this.setNodeQueryDone();
+
+		// Clear Permission Denied Status
+		if (this.permissionDeniedStatus) {
+			this.permissionDeniedStatus = false;
+		}
+	}
+
+	public setMsgSendHandler() {
+		const events = this.node.config.sendMsgEvent?.split(",");
+		if (!events) return;
+
+		if (events.includes("onConnected")) this.node.RED.events.on("Firebase:connected", this.sendMsgOnConnected);
+		if (events.includes("onDisconnect")) this.node.RED.events.on("Firebase:disconnect", this.sendMsgOnDisconnect);
+	}
+}

--- a/src/lib/types/OnDisconnectConfigType.ts
+++ b/src/lib/types/OnDisconnectConfigType.ts
@@ -17,6 +17,7 @@
 import { NodeDef } from "node-red";
 
 export enum Query {
+	"none",
 	"cancel",
 	"set",
 	"update",
@@ -25,7 +26,7 @@ export enum Query {
 }
 
 type PathType = "msg" | "str";
-type QueryType = "none" | keyof typeof Query;
+type QueryType = "msg" | keyof typeof Query;
 type SendMsgEvent = "" | "onConnected" | "onConnected,onDisconnect";
 
 export type OnDisconnectConfigType = NodeDef & {

--- a/src/lib/types/OnDisconnectConfigType.ts
+++ b/src/lib/types/OnDisconnectConfigType.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022-2023 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeDef } from "node-red";
+
+export enum Query {
+	"cancel",
+	"set",
+	"update",
+	"remove",
+	"setWithPriority",
+}
+
+type PathType = "msg" | "str";
+type QueryType = "none" | keyof typeof Query;
+type SendMsgEvent = "" | "onConnected" | "onConnected,onDisconnect";
+
+export type OnDisconnectConfigType = NodeDef & {
+	database: string;
+	path?: string;
+	pathType?: PathType;
+	queryType?: QueryType;
+	sendMsgEvent?: SendMsgEvent;
+};

--- a/src/lib/types/OnDisconnectNodeType.ts
+++ b/src/lib/types/OnDisconnectNodeType.ts
@@ -18,13 +18,13 @@ import { NodeMessage } from "node-red";
 import { FirebaseNode } from "./FirebaseNodeType";
 import { OnDisconnectConfigType } from "./OnDisconnectConfigType";
 
+export type SendMsgEvent = "connected" | "disconnect";
+
 export interface OutputMessageType extends NodeMessage {
 	payload: number;
 	event: SendMsgEvent;
 	topic: string;
 }
-
-export type SendMsgEvent = "connected" | "disconnect";
 
 export type OnDisconnectNodeType = FirebaseNode & {
 	config: OnDisconnectConfigType;

--- a/src/lib/types/OnDisconnectNodeType.ts
+++ b/src/lib/types/OnDisconnectNodeType.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022-2023 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeMessage } from "node-red";
+import { FirebaseNode } from "./FirebaseNodeType";
+import { OnDisconnectConfigType } from "./OnDisconnectConfigType";
+
+export interface OutputMessageType extends NodeMessage {
+	payload: number;
+	event: SendMsgEvent;
+	topic: string;
+}
+
+export type SendMsgEvent = "connected" | "disconnect";
+
+export type OnDisconnectNodeType = FirebaseNode & {
+	config: OnDisconnectConfigType;
+};

--- a/src/nodes/on-disconnect.ts
+++ b/src/nodes/on-disconnect.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2022-2023 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeAPI } from "node-red";
+import { OnDisconnect } from "../lib/onDisconnectNode";
+import { DatabaseNodeType } from "../lib/types/DatabaseNodeType";
+import { InputMessageType } from "../lib/types/FirebaseNodeType";
+import { OnDisconnectConfigType } from "../lib/types/OnDisconnectConfigType";
+import { OnDisconnectNodeType } from "../lib/types/OnDisconnectNodeType";
+
+module.exports = function (RED: NodeAPI) {
+	function OnDisconnectNode(this: OnDisconnectNodeType, config: OnDisconnectConfigType) {
+		RED.nodes.createNode(this, config);
+		const self = this;
+
+		self.config = config;
+		self.database = RED.nodes.getNode(config.database) as DatabaseNodeType | null;
+		self.RED = RED;
+
+		const firebase = new OnDisconnect(self);
+
+		firebase.registerNode();
+		firebase.setNodeStatus();
+		firebase.setMsgSendHandler();
+
+		self.on("input", (msg: InputMessageType, _send, done) => {
+			firebase
+				.setOnDisconnectQuery(msg)
+				.then(() => done())
+				.catch((error: Error) => self.onError(error, done));
+		});
+
+		self.on("close", (removed: boolean, done: () => void) => firebase.deregisterNode(removed, done));
+	}
+
+	RED.nodes.registerType("on-disconnect", OnDisconnectNode);
+};


### PR DESCRIPTION
## New Features

- `On Disconnect` Node

The `On Disconnect` node allows you to write or clear data when your client disconnects from the Database server. These updates occur whether your client disconnects cleanly or not, so you can rely on them to clean up data even if a connection is dropped or a client crashes.

Moreover, this node proposes to send a message when the client is connected and/or the client disconnects from the database.

The **Wiki** features this node [here](https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/on-disconnect) 😉 