### PR TITLE
Improve: Additional Claims Container

### DIFF
--- a/build/nodes/database.html
+++ b/build/nodes/database.html
@@ -101,7 +101,7 @@
 			defaults: {
 				name: { value: "My Database" },
 				authType: { value: "anonymous" },
-				claims: { value: {} },
+				claims: { value: {}, validate: isClaimsValid },
 				createUser: { value: false },
 				useClaims: { value: false },
 			},
@@ -283,6 +283,19 @@
 
 		function isClaimKeyValid(key) {
 			if (key.match(/^(acr|amr|at_hash|aud|auth_time|azp|cnf|c_hash|exp|iat|iss|jti|nbf|nonce|sub|firebase|user_id)$|^\s|\s$/)) return false;
+			return true;
+		}
+
+		function isClaimsValid(claims = {}) {
+			if (typeof claims !== "object") return false;
+
+			for (const v of Object.values(claims)) {
+				if (v.type.match(/^(num|date)$/) && (typeof v.value !== "number" || Number.isNaN(v.value))) return false;
+				if (v.type === "bool" && typeof v.value !== "boolean") return false;
+				if (v.type === "json" && typeof v.value !== "object") return false;
+				if (v.type === "str" && typeof v.value !== "string") return false;
+			}
+
 			return true;
 		}
 

--- a/build/nodes/database.html
+++ b/build/nodes/database.html
@@ -145,7 +145,12 @@
 					const value = $(this).find(`#node-config-input-claimsValue-case-${id}`).val();
 					const type = $(this).find(`#node-config-input-claimsValueType-case-${id}`).val();
 
-					node.claims[key] = { value: value, type: type };
+					const valueParsed = type === "date" ? Date.now() :
+						type === "num" ? Number(value) :
+						type === "bool" ? (value === "true" ? true : false) :
+						value;
+
+					node.claims[key] = { value: valueParsed, type: type };
 				});
 			},
 		});
@@ -176,14 +181,14 @@
 			const valueField = $(container).find(`#node-config-input-claimsValue-case-${id}`);
 
 			keyField.typedInput({ default: "str", types: [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isClaimKeyValid }] });
-			valueField.typedInput({ default: "str", typeField: `#node-config-input-claimsValueType-case-${id}`, types: ["flow", "global", "str", "num", "bool", "json", "bin", "date", "env"] });
+			valueField.typedInput({ default: "str", typeField: `#node-config-input-claimsValueType-case-${id}`, types: ["str", "num", "bool", "date"] });
 
 			if (Array.isArray(data)) {
 				const [key, object] = data;
 
 				keyField.typedInput("value", key);
-				valueField.typedInput("value", object.value);
-				valueField.typedInput("type", object.type);
+				valueField.typedInput("value", object.value?.toString() ?? "");
+				valueField.typedInput("type", object.type ?? "str");
 
 				data = {};
 				$(container).data("data", data);

--- a/build/nodes/database.html
+++ b/build/nodes/database.html
@@ -289,7 +289,8 @@
 		function isClaimsValid(claims = {}) {
 			if (typeof claims !== "object") return false;
 
-			for (const v of Object.values(claims)) {
+			for (const [k, v] of Object.entries(claims)) {
+				if (!isClaimKeyValid(k)) return false;
 				if (v.type.match(/^(num|date)$/) && (typeof v.value !== "number" || Number.isNaN(v.value))) return false;
 				if (v.type === "bool" && typeof v.value !== "boolean") return false;
 				if (v.type === "json" && typeof v.value !== "object") return false;

--- a/build/nodes/database.html
+++ b/build/nodes/database.html
@@ -144,13 +144,24 @@
 					const key = $(this).find(`#node-config-input-claimsKey-case-${id}`).val();
 					const value = $(this).find(`#node-config-input-claimsValue-case-${id}`).val();
 					const type = $(this).find(`#node-config-input-claimsValueType-case-${id}`).val();
+					try {
+						const valueParsed =
+							type === "date" ? Date.now() :
+							type === "num" ? Number(value) :
+							type === "bool" ? (value === "true" ? true : false) :
+							type === "json" ? JSON.parse(value) :
+							value;
 
-					const valueParsed = type === "date" ? Date.now() :
-						type === "num" ? Number(value) :
-						type === "bool" ? (value === "true" ? true : false) :
-						value;
+						if (type === "num" && Number.isNaN(valueParsed))
+							RED.notify("Additional Claims: Setted value is not a number!", "error");
 
-					node.claims[key] = { value: valueParsed, type: type };
+						node.claims[key] = { value: valueParsed, type: type };
+					} catch (error) {
+						// Save the value of field instead of the valueParsed
+						// Allows the user to re-modify the value
+						node.claims[key] = { value: value, type: type };
+						RED.notify("Additional Claims: Setted value is invalid JSON!", "error");
+					}
 				});
 			},
 		});
@@ -181,13 +192,13 @@
 			const valueField = $(container).find(`#node-config-input-claimsValue-case-${id}`);
 
 			keyField.typedInput({ default: "str", types: [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isClaimKeyValid }] });
-			valueField.typedInput({ default: "str", typeField: `#node-config-input-claimsValueType-case-${id}`, types: ["str", "num", "bool", "date"] });
+			valueField.typedInput({ default: "str", typeField: `#node-config-input-claimsValueType-case-${id}`, types: ["str", "num", "bool", "date", "json"] });
 
 			if (Array.isArray(data)) {
 				const [key, object] = data;
 
 				keyField.typedInput("value", key);
-				valueField.typedInput("value", object.value?.toString() ?? "");
+				valueField.typedInput("value", typeof object.value === "object" ? JSON.stringify(object.value) : object.value?.toString() ?? "");
 				valueField.typedInput("type", object.type ?? "str");
 
 				data = {};


### PR DESCRIPTION
## Fixes

- Options allowed are `string`, `number`, `boolean`, `date` and `json`
- Saved value does not have the correct type (always string)

## New Features

- Validation of Claims (does the value match the type and the key is it allowed)
- A notification is sent if the field value is incorrect