### PR TITLE
Feature: New options for the `Value` field of the `Query Constraints` container

### DIFF
--- a/build/nodes/firebase-get.html
+++ b/build/nodes/firebase-get.html
@@ -119,7 +119,7 @@
 				constraintType.typedInput("value", key);
 
 				if (value && typeof value === "object") {
-					valueField.typedInput("value", value.value ?? "");
+					valueField.typedInput("value", value.value?.toString() ?? "");
 					valueField.typedInput("type", value.type ?? "str");
 					childField.typedInput("value", value.key ?? "");
 				} else {
@@ -177,9 +177,16 @@
 					case "endBefore":
 					case "equalTo":
 					case "startAfter":
-					case "startAt":
-						node.constraint[constraintType] = { value: value, key: child, type: type };
+					case "startAt": {
+						const valueParsed = type === "date" ? Date.now() :
+							type === "null" ? null :
+							type === "num" ? Number(value) :
+							type === "bool" ? (value === "true" ? true : false) :
+							value;
+
+						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
 						break;
+					}
 					case "limitToFirst":
 					case "limitToLast":
 						node.constraint[constraintType] = parseInt(value);
@@ -209,7 +216,7 @@
 				case "equalTo":
 				case "startAfter":
 				case "startAt":
-					value.typedInput("types", ["bool", "num", "str"]);
+					value.typedInput("types", ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
 					valueContainer.css("padding-bottom", "5px");
 					child.typedInput("show");
 					break;

--- a/build/nodes/firebase-get.html
+++ b/build/nodes/firebase-get.html
@@ -216,7 +216,7 @@
 				case "equalTo":
 				case "startAfter":
 				case "startAt":
-					value.typedInput("types", ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
+					value.typedInput("types", ["flow", "global", "msg", "bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
 					valueContainer.css("padding-bottom", "5px");
 					child.typedInput("show");
 					break;

--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -112,7 +112,7 @@
 				constraintType.typedInput("value", key);
 
 				if (value && typeof value === "object") {
-					valueField.typedInput("value", value.value ?? "");
+					valueField.typedInput("value", value.value?.toString() ?? "");
 					valueField.typedInput("type", value.type ?? "str");
 					childField.typedInput("value", value.key ?? "");
 				} else {
@@ -164,9 +164,16 @@
 					case "endBefore":
 					case "equalTo":
 					case "startAfter":
-					case "startAt":
-						node.constraint[constraintType] = { value: value, key: child, type: type };
+					case "startAt": {
+						const valueParsed = type === "date" ? Date.now() :
+							type === "null" ? null :
+							type === "num" ? Number(value) :
+							type === "bool" ? (value === "true" ? true : false) :
+							value;
+
+						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
 						break;
+					}
 					case "limitToFirst":
 					case "limitToLast":
 						node.constraint[constraintType] = parseInt(value);
@@ -196,7 +203,7 @@
 				case "equalTo":
 				case "startAfter":
 				case "startAt":
-					value.typedInput("types", ["bool", "num", "str"]);
+					value.typedInput("types", ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
 					valueContainer.css("padding-bottom", "5px");
 					child.typedInput("show");
 					break;

--- a/src/lib/firebaseNode.ts
+++ b/src/lib/firebaseNode.ts
@@ -196,10 +196,15 @@ export class Firebase {
 					if (typeof value !== "object") throw new Error(`The value of the "${method}" constraint must be an object!`);
 					if (value.value === undefined)
 						throw new Error(`The value of the "${method}" constraint must be an object containing 'value' as key.`);
-					if (typeof value.value !== "string" && typeof value.value !== "boolean" && typeof value.value !== "number")
-						throw new Error(`The value of the "${method}.value" constraint must be a boolean or number or string!`);
+					if (
+						typeof value.value !== "string" &&
+						typeof value.value !== "boolean" &&
+						typeof value.value !== "number" &&
+						value.value !== null
+					)
+						throw new Error(`The value of the "${method}.value" constraint must be a boolean, number, string or null!`);
 
-					if (value.key && typeof value.key !== "string")
+					if (value.key === null || (value.key && typeof value.key !== "string"))
 						throw new Error(`The value of the "${method}.key" constraint must be a string!`);
 					break;
 				case "limitToFirst":

--- a/src/lib/firebaseNode.ts
+++ b/src/lib/firebaseNode.ts
@@ -270,6 +270,7 @@ export class Firebase {
 
 		const constraints = deepCopy(this.node.config.constraint ?? {});
 
+		// Firebase IN (no context/msg here)
 		if (!msg) return constraints;
 
 		for (const value of Object.values(constraints)) {
@@ -461,7 +462,7 @@ export class Firebase {
 	 * @returns The content of the value associated to the type
 	 */
 	private valueFromType(msg: InputMessageType, value: ValueFieldType, type: ChildFieldType): ValueFieldType {
-		if (type === "bool" || type === "date" || type === "num" || type === "str") return value;
+		if (type === "bool" || type === "date" || type === "null" || type === "num" || type === "str") return value;
 
 		if (type !== "flow" && type !== "global" && type !== "msg")
 			throw new Error("The type of value field should be 'flow', 'global' or 'msg', please re-configure this node.");

--- a/src/lib/types/FirebaseNodeType.ts
+++ b/src/lib/types/FirebaseNodeType.ts
@@ -35,7 +35,7 @@ export enum QueryConstraint {
 }
 
 export type ValueFieldType = number | string | boolean | null;
-export type ChildFieldType = "bool" | "date" | "flow" | "global" | "msg" | "num" | "str";
+export type ChildFieldType = "bool" | "date" | "flow" | "global" | "msg" | "null" | "num" | "str";
 
 interface RangeQueryType {
 	key?: string;

--- a/src/lib/types/FirebaseNodeType.ts
+++ b/src/lib/types/FirebaseNodeType.ts
@@ -34,18 +34,28 @@ export enum QueryConstraint {
 	"startAt",
 }
 
-/* eslint-disable no-mixed-spaces-and-tabs */
-export type QueryConstraintType =
-	| Record<"orderByKey" | "orderByPriority" | "orderByValue", null | undefined>
-	| Record<"limitToFirst" | "limitToLast", number>
-	| Record<"orderByChild", string>
-	| Record<
-			"endAt" | "endBefore" | "equalTo" | "startAfter" | "startAt",
-			{
-				key?: string;
-				value: number | string | boolean | null;
-			}
-	  >;
+export type ValueFieldType = number | string | boolean | null;
+export type ChildFieldType = "bool" | "date" | "flow" | "global" | "msg" | "num" | "str";
+
+interface RangeQueryType {
+	key?: string;
+	value: ValueFieldType;
+	type: ChildFieldType;
+}
+
+export interface QueryConstraintType {
+	orderByKey?: null;
+	orderByPriority?: null;
+	orderByValue?: null;
+	limitToFirst?: number;
+	limitToLast?: number;
+	orderByChild?: string;
+	endAt?: RangeQueryType;
+	endBefore?: RangeQueryType;
+	equalTo?: RangeQueryType;
+	startAfter?: RangeQueryType;
+	startAt?: RangeQueryType;
+}
 
 export type DataSnapshot = database.DataSnapshot | adminDatabase.DataSnapshot;
 export type DBRef = adminDatabase.Reference | adminDatabase.Query;


### PR DESCRIPTION
## Fixes

- Saved value of `Value` field does not have the correct type (always string)
- `checkQueryConstraint` accepts now `null` as value for Range Queries

## New Features

- (Firebase-get) Options `date`, `flow`, `global`, `msg` and `null` have been added
- (Firebase-in) Options `date` and `null` have been added