### PR TITLE
Fix: Invalid `API Key` input pattern (#48)

### DIFF
--- a/build/nodes/database.html
+++ b/build/nodes/database.html
@@ -90,7 +90,7 @@
 		RED.nodes.registerType("database-config", {
 			category: "config",
 			credentials: {
-				apiKey: { type: "text", validate: RED.validators.regex(/^AIza[a-zA-Z0-9]{35}$/) },
+				apiKey: { type: "text", validate: RED.validators.regex(/^AIza[a-zA-Z0-9-_\\]{35}$/) },
 				clientEmail: { type: "password" },
 				email: { type: "text", validate: RED.validators.regex(/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/i) },
 				password: { type: "password", validate: RED.validators.regex(/^.+$/) },


### PR DESCRIPTION
Fixes #48

`API Key` containing the following character(s) throw an invalid input pattern:
- dashes `-`
- underlines `_` or backward slashes `\`