### PR TITLE
Support for built-in `TIMESTAMP` and `increment` server values

### DIFF
--- a/build/nodes/locales/de/firebase-out.html
+++ b/build/nodes/locales/de/firebase-out.html
@@ -74,7 +74,7 @@
 	<pre>
 {
   payload: "INCREMENT 1",
-  method: "update",
+  method: "set",
   path: "updateIndex"
 }</pre>
 	<p>

--- a/build/nodes/locales/de/firebase-out.html
+++ b/build/nodes/locales/de/firebase-out.html
@@ -55,6 +55,29 @@
 		der Eigenschaft <code>msg.topic</code> definiert werden.
 	</p>
 	<p>
+		Mit dem reservierten Schlüsselwort <code>"TIMESTAMP"</code> können Sie den Datenbank-Zeitstempel verwenden.
+		Es muss im String-Format geschrieben werden und kann auch in einem Array oder einem Objekt verwendet werden.
+		Im folgenden Beispiel wird die Serverzeit im UNIX-Format an den Speicherort "currentServerTimestamp" geschrieben.
+	</p>
+	<pre>
+{
+  payload: "TIMESTAMP",
+  method: "set",
+  path: "currentServerTimestamp"
+}</pre>
+	<p>
+		Das reservierte Schlüsselwort <code>"INCREMENT [delta]"</code>, dem eine positive oder negative Ganzzahl vorangestellt ist, ermöglicht die Inkrementierung
+		ein numerischer Wert eines Deltas.
+		Es muss im String-Format geschrieben werden und kann in einem Array oder einem Objekt verwendet werden.
+		Im folgenden Beispiel wird der Wert am Speicherort „updateIndex“ um 1 erhöht.
+	</p>
+	<pre>
+{
+  payload: "INCREMENT 1",
+  method: "update",
+  path: "updateIndex"
+}</pre>
+	<p>
 		Erfahren Sie
 		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-out">hier</a> mehr
 		darüber, wie sie diesen Node verwenden können.

--- a/build/nodes/locales/en-US/firebase-out.html
+++ b/build/nodes/locales/en-US/firebase-out.html
@@ -64,7 +64,7 @@
 	<pre>
 {
   payload: "INCREMENT 1",
-  method: "update",
+  method: "set",
   path: "updateIndex"
 }</pre>
 	<p>

--- a/build/nodes/locales/en-US/firebase-out.html
+++ b/build/nodes/locales/en-US/firebase-out.html
@@ -45,6 +45,29 @@
 		with the <code>msg.topic</code> property
 	</p>
 	<p>
+		The reserved keyword <code>"TIMESTAMP"</code> allows you to use the database timestamp.
+		It must be written in string format and can also be used in an array or an object.
+		The following example will write the server time in UNIX format to the "currentServerTimestamp" location.
+	</p>
+	<pre>
+{
+  payload: "TIMESTAMP",
+  method: "set",
+  path: "currentServerTimestamp"
+}</pre>
+	<p>
+		The reserved keyword <code>"INCREMENT [delta]"</code> preceded by a positive or negative integer allows you
+		to increment a numerical value by a delta.
+		It must be written in string format and can be used in an array or an object.
+		The following example will increment the value by 1 at the "updateIndex" location.
+	</p>
+	<pre>
+{
+  payload: "INCREMENT 1",
+  method: "update",
+  path: "updateIndex"
+}</pre>
+	<p>
 		Learn more about how to use this node
 		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-out">here</a>.
 	</p>

--- a/build/nodes/locales/fr/database.html
+++ b/build/nodes/locales/fr/database.html
@@ -40,8 +40,8 @@
 		<strong>Claims</strong> : revendications supplémentaires à inclure dans le jeton personnalisé, qui sera disponible
 		dans les objets <code>auth</code> / <code>request.auth</code> de vos règles de sécurité.
 		</p>
-	<p>
-		En savoir plus sur la configuration de l'authentification
-		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/config-node">ici</a>.
-	</p>
+		<p>
+			Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/config-node">ici</a> 
+			pour en savoir plus sur l'utilisation de ce noeud.
+		</p>
 </script>

--- a/build/nodes/locales/fr/firebase-get.html
+++ b/build/nodes/locales/fr/firebase-get.html
@@ -81,8 +81,8 @@
     "key": "nom"
   }
 }</pre>
-	<p>
-		En savoir plus sur l'utilisation de ce noeud
-		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-get">ici</a>.
-	</p>
+<p>
+	Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-get">ici</a> 
+	pour en savoir plus sur l'utilisation de ce noeud.
+</p>
 </script>

--- a/build/nodes/locales/fr/firebase-in.html
+++ b/build/nodes/locales/fr/firebase-in.html
@@ -50,7 +50,7 @@
 		les données, ou <strong>une chaîne de caractères</strong> pour envoyer les données sous forme de chaîne de caractères.
 	</p>
 	<p>
-		En savoir plus sur l'utilisation de ce noeud
-		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">ici</a>.
+		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">ici</a> 
+		pour en savoir plus sur l'utilisation de ce noeud.
 	</p>
 </script>

--- a/build/nodes/locales/fr/firebase-out.html
+++ b/build/nodes/locales/fr/firebase-out.html
@@ -45,7 +45,30 @@
 		avec la propriété <code>msg.topic</code>.
 	</p>
 	<p>
-		En savoir plus sur l'utilisation de ce noeud
-		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-out">ici</a>.
+		Le mot-clé réservé <code>"TIMESTAMP"</code> permet d'utiliser l'horodatage de la base de données.
+		Il doit être écrit au format chaîne de caractères et peut également être utilisé dans un tableau ou un objet.
+		L'exemple suivant écrira l'heure du serveur au format UNIX à l'emplacement "currentServerTimestamp".
+	</p>
+	<pre>
+{
+  payload: "TIMESTAMP",
+  method: "set",
+  path: "currentServerTimestamp"
+}</pre>
+	<p>
+		Le mot-clé réservé <code>"INCREMENT [delta]"</code> précédé d'un entier positif ou négatif permet d'incrémenter
+		une valeur numérique d'un delta.
+		Il doit être écrit au format chaîne de caractères et peut être utilisé dans un tableau ou un objet.
+		L'exemple suivant incrémentera la valeur de 1 à l'emplacement "updateIndex".
+	</p>
+	<pre>
+{
+  payload: "INCREMENT 1",
+  method: "update",
+  path: "updateIndex"
+}</pre>
+	<p>
+		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-out">ici</a> 
+		pour en savoir plus sur l'utilisation de ce noeud.
 	</p>
 </script>

--- a/build/nodes/locales/fr/firebase-out.html
+++ b/build/nodes/locales/fr/firebase-out.html
@@ -64,7 +64,7 @@
 	<pre>
 {
   payload: "INCREMENT 1",
-  method: "update",
+  method: "set",
   path: "updateIndex"
 }</pre>
 	<p>

--- a/build/nodes/locales/fr/on-disconnect.html
+++ b/build/nodes/locales/fr/on-disconnect.html
@@ -56,7 +56,7 @@
 		avec la propriété <code>msg.topic</code>
 	</p>
 	<p>
-		En savoir plus sur l'utilisation de ce noeud
-		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/on-disconnect">ici</a>.
+		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/on-disconnect">ici</a> 
+		pour en savoir plus sur l'utilisation de ce noeud.
 	</p>
 </script>

--- a/examples/demo-flow.json
+++ b/examples/demo-flow.json
@@ -30,7 +30,7 @@
     ],
     "x": 14,
     "y": 19,
-    "w": 952,
+    "w": 972,
     "h": 242
   },
   {
@@ -71,6 +71,28 @@
     "y": 299,
     "w": 972,
     "h": 542
+  },
+  {
+    "id": "2c9b5f4cd21831cb",
+    "type": "group",
+    "z": "13c4e8e8f85d50b9",
+    "name": "",
+    "style": {
+      "stroke": "#3f93cf",
+      "label": true
+    },
+    "nodes": [
+      "b6fe7042bd85ef5d",
+      "5395c1e6288eedd1",
+      "a946387bbf0e9716",
+      "909e56335c63fd16",
+      "a4532a063e702429",
+      "e8373909bb49fb32"
+    ],
+    "x": 14,
+    "y": 859,
+    "w": 972,
+    "h": 182
   },
   {
     "id": "5792767043952f56",
@@ -267,7 +289,7 @@
     "complete": "false",
     "statusVal": "",
     "statusType": "auto",
-    "x": 860,
+    "x": 880,
     "y": 100,
     "wires": []
   },
@@ -284,7 +306,7 @@
     "complete": "false",
     "statusVal": "",
     "statusType": "auto",
-    "x": 860,
+    "x": 880,
     "y": 220,
     "wires": []
   },
@@ -675,6 +697,148 @@
     "info": "",
     "x": 680,
     "y": 760,
+    "wires": []
+  },
+  {
+    "id": "b6fe7042bd85ef5d",
+    "type": "firebase-out",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "Overwrite Index",
+    "database": "e8796a1869e179bc",
+    "path": "index",
+    "pathType": "str",
+    "priority": "",
+    "queryType": "set",
+    "x": 380,
+    "y": 900,
+    "wires": []
+  },
+  {
+    "id": "5395c1e6288eedd1",
+    "type": "inject",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "Set index to 1",
+    "props": [
+      {
+        "p": "payload"
+      },
+      {
+        "p": "topic",
+        "vt": "str"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "1",
+    "payloadType": "num",
+    "x": 130,
+    "y": 900,
+    "wires": [
+      [
+        "b6fe7042bd85ef5d"
+      ]
+    ]
+  },
+  {
+    "id": "a946387bbf0e9716",
+    "type": "inject",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "Increment by 1",
+    "props": [
+      {
+        "p": "payload"
+      },
+      {
+        "p": "topic",
+        "vt": "str"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "INCREMENT 1",
+    "payloadType": "str",
+    "x": 140,
+    "y": 960,
+    "wires": [
+      [
+        "b6fe7042bd85ef5d"
+      ]
+    ]
+  },
+  {
+    "id": "909e56335c63fd16",
+    "type": "inject",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "Decrement by 1",
+    "props": [
+      {
+        "p": "payload"
+      },
+      {
+        "p": "topic",
+        "vt": "str"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "INCREMENT -1",
+    "payloadType": "str",
+    "x": 140,
+    "y": 1000,
+    "wires": [
+      [
+        "b6fe7042bd85ef5d"
+      ]
+    ]
+  },
+  {
+    "id": "a4532a063e702429",
+    "type": "firebase-in",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "Index Changes",
+    "constraint": {},
+    "database": "e8796a1869e179bc",
+    "listenerType": "value",
+    "outputType": "auto",
+    "path": "index",
+    "useConstraint": false,
+    "x": 660,
+    "y": 900,
+    "wires": [
+      [
+        "e8373909bb49fb32"
+      ]
+    ]
+  },
+  {
+    "id": "e8373909bb49fb32",
+    "type": "debug",
+    "z": "13c4e8e8f85d50b9",
+    "g": "2c9b5f4cd21831cb",
+    "name": "debug 13",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 880,
+    "y": 900,
     "wires": []
   },
   {

--- a/examples/on-disconnect-flow.json
+++ b/examples/on-disconnect-flow.json
@@ -266,35 +266,10 @@
     "wires": []
   },
   {
-    "id": "a667ac6296c9527e",
-    "type": "function",
-    "z": "73d271d7b26c7d87",
-    "name": "Use Server Timestamp",
-    "func": "// Don't forget to look at Setup panel\n// Returns a placeholder value for auto-populating the current timestamp\n// as determined by the Firebase servers.\nreturn {\n    payload: firebaseDatabase.serverTimestamp()\n};",
-    "outputs": 1,
-    "timeout": 0,
-    "noerr": 0,
-    "initialize": "",
-    "finalize": "",
-    "libs": [
-      {
-        "var": "firebaseDatabase",
-        "module": "firebase/database"
-      }
-    ],
-    "x": 300,
-    "y": 320,
-    "wires": [
-      [
-        "b229f7c2aafdde4c"
-      ]
-    ]
-  },
-  {
     "id": "878787e8146fe6cd",
     "type": "inject",
     "z": "73d271d7b26c7d87",
-    "name": "Inject",
+    "name": "Use Server Timestamp",
     "props": [
       {
         "p": "payload"
@@ -305,13 +280,13 @@
     "once": false,
     "onceDelay": 0.1,
     "topic": "",
-    "payload": "{}",
-    "payloadType": "json",
-    "x": 110,
+    "payload": "TIMESTAMP",
+    "payloadType": "str",
+    "x": 160,
     "y": 320,
     "wires": [
       [
-        "a667ac6296c9527e"
+        "b229f7c2aafdde4c"
       ]
     ]
   },

--- a/src/lib/firebaseNode.ts
+++ b/src/lib/firebaseNode.ts
@@ -274,8 +274,8 @@ export class Firebase {
 			case "string": {
 				if (/^\s*TIMESTAMP\s*$/.test(payload)) return ServerValue.TIMESTAMP;
 
-				if (/^\s*INCREMENT\s*-?\d+\s*$/.test(payload)) {
-					const deltaString = payload.match(/-?\d+/)?.[0] || "";
+				if (/^\s*INCREMENT\s*-?\d+\.?\d*\s*$/.test(payload)) {
+					const deltaString = payload.match(/-?\d+\.?\d*/)?.[0] || "";
 					const delta = Number(deltaString);
 
 					if (Number.isNaN(delta) || !Number.isInteger(delta))

--- a/src/lib/onDisconnectNode.ts
+++ b/src/lib/onDisconnectNode.ts
@@ -36,10 +36,6 @@ import { printEnumKeys } from "./utils";
  * @class
  */
 export class OnDisconnect extends Firebase {
-	constructor(protected node: OnDisconnectNodeType) {
-		super(node);
-	}
-
 	/**
 	 * Callback called for the `Firebase:connected` event.
 	 */
@@ -49,6 +45,10 @@ export class OnDisconnect extends Firebase {
 	 * Callback called for the `Firebase:disconnect` event.
 	 */
 	private sendMsgOnDisconnect = () => this.sendMsgOnEvent("disconnect");
+
+	constructor(protected node: OnDisconnectNodeType) {
+		super(node);
+	}
 
 	/**
 	 * Checks if the priority is valid otherwise throws an error.
@@ -193,6 +193,7 @@ export class OnDisconnect extends Firebase {
 	public async setOnDisconnectQuery(msg: InputMessageType) {
 		const path = this.getPath(msg);
 		const query = this.getQuery(msg);
+		const payload = this.evaluatePayloadForServerValue(msg.payload);
 
 		if (!this.db) return;
 		if (query === "none") return Promise.resolve();
@@ -209,17 +210,17 @@ export class OnDisconnect extends Firebase {
 				await databaseRef[query]();
 				break;
 			case "set":
-				await databaseRef[query](msg.payload);
+				await databaseRef[query](payload);
 				break;
 			case "update":
-				if (msg.payload && typeof msg.payload === "object") {
-					await databaseRef[query](msg.payload);
+				if (payload && typeof payload === "object") {
+					await databaseRef[query](payload);
 					break;
 				}
 
 				throw new Error("msg.payload must be an object with 'update' query.");
 			case "setWithPriority":
-				await databaseRef[query](msg.payload, this.getPriority(msg));
+				await databaseRef[query](payload, this.getPriority(msg));
 				break;
 		}
 

--- a/src/lib/types/UtilType.ts
+++ b/src/lib/types/UtilType.ts
@@ -16,7 +16,7 @@
 
 type TupleEntry<T extends readonly unknown[], I extends unknown[] = [], R = never> = T extends readonly [
 	infer Head,
-	...infer Tail
+	...infer Tail,
 ]
 	? TupleEntry<Tail, [...I, unknown], R | [`${I["length"]}`, Head]>
 	: R;


### PR DESCRIPTION
## Timestamp

Returns a placeholder value for auto-populating the current timestamp (time since the Unix epoch, in milliseconds) as determined by the Firebase servers.

For example: sending the following message to the `Firebase out` node,

```js
{
  payload: "TIMESTAMP",
  method: "set",
  path: "currentServerTimestamp"
}
```
amounts to:

```js
const timestampRef = ref.child("currentServerTimestamp");
timestampRef.set(ServerValue.TIMESTAMP);
```

## Increment

Returns a placeholder value that can be used to atomically increment the current database value by the provided delta.

For example: sending the following message to the `Firebase out` node,

```js
{
  payload: "INCREMENT 1",
  method: "set",
  path: "updateIndex"
}
```

amounts to:

```js
const indexRef = ref.child("updateIndex");
indexRef.set(ServerValue.increment(1));
```

Play with examples to better understand 🙂 