### PR TITLE
Feature: dynamically set `Firebase-in` node properties

### DIFF
--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -27,9 +27,12 @@
 				name: { value: "" },
 				constraint: { value: {}, validate: isConstraintValid },
 				database: { value: "", type: "firebase-config" },
-				listenerType: { value: "value", validate: RED.validators.regex(/^(value|child_added|child_changed|child_moved|child_removed)$/) },
+				inputs: { value: 0 },
+				listenerType: { value: "value", validate: RED.validators.regex(/^(none|value|child_added|child_changed|child_moved|child_removed)$/) },
 				outputType: { value: "auto", validate: RED.validators.regex(/^(auto|string)$/) },
+				passThrough: { value: false },
 				path: { value: "test/stream", validate: (v) => !v.match(/^\s+|[.#$\[\]]$/g) },
+				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
 				useConstraint: { value: false },
 			},
 			inputs: 0,
@@ -54,6 +57,13 @@
 					));
 				}
 
+				$("#node-input-path").typedInput({
+					typeField: "#node-input-pathType",
+					types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
+				});
+
+				$("#node-input-listenerType").on("change", listenerTypeHandler);
+
 				constraintContainer.css({ "min-height": "150px", "min-width": "300px" }).editableList({
 					addButton: node._("firebase-in.addConstraint"),
 					addItem: addItem.bind(node),
@@ -63,7 +73,12 @@
 
 				useConstraint.on("change", useConstraintHandler.bind(node));
 			},
-			oneditsave: saveItems,
+			oneditsave: function () {
+				saveItems.call(this);
+				
+				const inputs = $("#node-input-listenerType").val() === "none" ? 1 : 0;
+				$("#node-input-inputs").val(inputs);
+			},
 		});
 
 		function addItem(container, index, data) {
@@ -163,6 +178,19 @@
 			}
 
 			return true;
+		}
+
+		function isPathValid(path) {
+			if (typeof path !== "string") return false;
+			if (path.match(/^\s|[.#$\[\]]/g)) return false;
+			return true;
+		}
+
+		function listenerTypeHandler() {
+			const defaultTypes = ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }]
+			const types = $("#node-input-listenerType").val() === "none" ? defaultTypes : [defaultTypes[1]];
+
+			$("#node-input-path").typedInput("types", types);
 		}
 
 		function saveItems() {
@@ -281,8 +309,10 @@
 	</div>
 
 	<div class="form-row">
+		<input type="hidden" id="node-input-inputs" />
 		<label for="node-input-listenerType"><i class="fa fa-bars"></i> <span data-i18n="firebase-in.label.listener"></span></label>
 		<select id="node-input-listenerType" style="width:70%;">
+			<option value="none" data-i18n="firebase-in.listenerType.none"></option>
 			<option value="value" data-i18n="firebase-in.listenerType.value"></option>
 			<option value="child_added" data-i18n="firebase-in.listenerType.child_added"></option>
 			<option value="child_changed" data-i18n="firebase-in.listenerType.child_changed"></option>
@@ -304,6 +334,7 @@
 	<div class="form-row">
 		<label for="node-input-path"><i class="fa fa-sitemap"></i> <span data-i18n="firebase-in.label.path"></span></label>
 		<input type="text" id="node-input-path" style="width:70%;" />
+		<input type="hidden" id="node-input-pathType" />
 	</div>
 
 	<div class="form-row">
@@ -312,6 +343,12 @@
 			<option value="auto" data-i18n="firebase-in.outputType.auto"></option>
 			<option value="string" data-i18n="firebase-in.outputType.string"></option>
 		</select>
+	</div>
+
+	<div class="form-row">
+		<label for="node-input-passThrough"></label>
+		<input type="checkbox" id="node-input-passThrough" style="display:inline-block; width:15px; vertical-align:baseline;" />
+		<span data-i18n="firebase-in.passThrough"></span>
 	</div>
 
 	<div class="form-row">

--- a/build/nodes/locales/de/firebase-in.html
+++ b/build/nodes/locales/de/firebase-in.html
@@ -45,7 +45,6 @@
 		<li><code>Kind verschoben</code></li>
 		<li><code>Kind gelöscht</code></li>
 	</ul>
-	<p>Sie können Beschränkungen für die Abfrage definieren, um Ihre Daten zu sortieren und zu ordnen.</p>
 	<p>
 		Der <strong>Pfad</strong> bestimmt, von wo die Daten gelesen werden. Er kann leer sein, in diesem Fall kommen die
 		Daten von der Wurzel der Datenbank kommen.
@@ -54,6 +53,35 @@
 		<strong>Ausgabe</strong> kann auf <strong>Automatisch erkennen</strong> gesetzt werden, um ein Objekt zu senden, das
 		die Daten enthält, oder <strong>eine Zeichenkette</strong> um die Daten als Zeichenkette zu senden.
 	</p>
+	<p>
+		Sie können Einschränkungen für die Abfrage definieren, um Ihre Daten zu sortieren und zu ordnen. Sie können eine
+		oder mehrere der folgenden Einschränkungen in der Eigenschaft <code>msg.method</code> oder direkt im Node
+		definieren:
+	</p>
+	<ul>
+		<li><code>endAt</code><span class="property-type">Objekt</span></li>
+		<li><code>endBefore</code><span class="property-type">Objekt</span></li>
+		<li><code>equalTo</code><span class="property-type">Objekt</span></li>
+		<li><code>limitToFirst</code><span class="property-type">Zahl</span></li>
+		<li><code>limitToLast</code><span class="property-type">Zahl</span></li>
+		<li><code>orderByChild</code><span class="property-type">Zeichenkette</span></li>
+		<li><code>orderByKey</code><span class="property-type">Null</span></li>
+		<li><code>orderByPriority</code><span class="property-type">Null</span></li>
+		<li><code>orderByValue</code><span class="property-type">Null</span></li>
+		<li><code>startAfter</code><span class="property-type">Objekt</span></li>
+		<li><code>startAt</code><span class="property-type">Objekt</span></li>
+	</ul>
+	<p><code>msg.method</code> schaut folgendermaßen aus:</p>
+	<pre>
+{
+  "orderByChild": "name",
+  "limitToFirst": 5,
+  "startAt": {
+    "value": "Alex",
+    "key": "name"
+  }
+}</pre
+	>
 	<p>
 		Erfahren sie
 		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">hier</a> mehr

--- a/build/nodes/locales/de/firebase-in.json
+++ b/build/nodes/locales/de/firebase-in.json
@@ -9,6 +9,7 @@
       "name": "Name"
     },
     "listenerType": {
+      "none": "- verwende msg.listener -",
       "value": "Wert",
       "child_added": "Kind hinzugefügt",
       "child_changed": "Kind geändert",
@@ -38,6 +39,7 @@
       "child": "Kind Schlüssel"
     },
     "useConstraint": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
-    "addConstraint": "Abfrageeinschränkungen hinzufügen"
+    "addConstraint": "Abfrageeinschränkungen hinzufügen",
+    "passThrough": "Die Nachricht durchreichen, wenn eine Nachricht ankommt?"
   }
 }

--- a/build/nodes/locales/en-US/firebase-in.html
+++ b/build/nodes/locales/en-US/firebase-in.html
@@ -37,7 +37,6 @@
 		<li><code>Child Moved</code></li>
 		<li><code>Child Removed</code></li>
 	</ul>
-	<p>You can define constraint(s) for the query to sort and order your data.</p>
 	<p>
 		The <strong>Path</strong> determines where the data will be read from. It can be empty, in this case the data sent
 		comes from the root of the database.
@@ -46,6 +45,34 @@
 		<strong>Output</strong> can be set to <strong>auto-detect</strong> to send an object containing the data, or
 		<strong>a String</strong> to send the data as a string.
 	</p>
+	<p>
+		You can define query constraint(s) to sort and order your data. You can define one or more of the following
+		constraints in the <code>msg.method</code> property or directly in the node:
+	</p>
+	<ul>
+		<li><code>endAt</code><span class="property-type">object</span></li>
+		<li><code>endBefore</code><span class="property-type">object</span></li>
+		<li><code>equalTo</code><span class="property-type">object</span></li>
+		<li><code>limitToFirst</code><span class="property-type">number</span></li>
+		<li><code>limitToLast</code><span class="property-type">number</span></li>
+		<li><code>orderByChild</code><span class="property-type">string</span></li>
+		<li><code>orderByKey</code><span class="property-type">null</span></li>
+		<li><code>orderByPriority</code><span class="property-type">null</span></li>
+		<li><code>orderByValue</code><span class="property-type">null</span></li>
+		<li><code>startAfter</code><span class="property-type">object</span></li>
+		<li><code>startAt</code><span class="property-type">object</span></li>
+	</ul>
+	<p>The <code>msg.method</code> will look like this:</p>
+	<pre>
+{
+  "orderByChild": "name",
+  "limitToFirst": 5,
+  "startAt": {
+    "value": "Alex",
+    "key": "name"
+  }
+}</pre
+	>
 	<p>
 		Learn more about how to use this node
 		<a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">here</a>.

--- a/build/nodes/locales/en-US/firebase-in.json
+++ b/build/nodes/locales/en-US/firebase-in.json
@@ -9,6 +9,7 @@
       "name": "Name"
     },
     "listenerType": {
+      "none": "- use msg.listener -",
       "value": "Value",
       "child_added": "Child Added",
       "child_changed": "Child Changed",
@@ -38,6 +39,7 @@
       "child": "Child Key"
     },
     "useConstraint": "Use Query Constraint to sort and order your data.",
-    "addConstraint": "Add Query Constraint Set"
+    "addConstraint": "Add Query Constraint Set",
+    "passThrough": "If a message arrives, pass through the message?"
   }
 }

--- a/build/nodes/locales/fr/firebase-in.html
+++ b/build/nodes/locales/fr/firebase-in.html
@@ -45,7 +45,6 @@
 		<li><code>Enfant déplacé</code></li>
 		<li><code>Enfant supprimé</code></li>
 	</ul>
-	<p>Vous pouvez définir des contraintes pour la requête afin de trier et d'ordonner vos données.</p>
 	<p>
 		Le <strong>Chemin</strong> détermine où les données seront lues. Il peut être vide, dans ce cas les données envoyées
 		proviennent de la racine de la base de données.
@@ -56,7 +55,35 @@
 		caractères.
 	</p>
 	<p>
-		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">ici</a> 
+		Vous pouvez définir des contraintes pour la requête afin de trier et d'ordonner vos données. Vous pouvez définir une
+		ou plusieurs des contraintes suivantes dans la propriété <code>msg.method</code> ou directement dans le noeud :
+	</p>
+	<ul>
+		<li><code>endAt</code><span class="property-type">objet</span></li>
+		<li><code>endBefore</code><span class="property-type">objet</span></li>
+		<li><code>equalTo</code><span class="property-type">objet</span></li>
+		<li><code>limitToFirst</code><span class="property-type">nombre</span></li>
+		<li><code>limitToLast</code><span class="property-type">nombre</span></li>
+		<li><code>orderByChild</code><span class="property-type">chaîne de caractères</span></li>
+		<li><code>orderByKey</code><span class="property-type">null</span></li>
+		<li><code>orderByPriority</code><span class="property-type">null</span></li>
+		<li><code>orderByValue</code><span class="property-type">null</span></li>
+		<li><code>startAfter</code><span class="property-type">objet</span></li>
+		<li><code>startAt</code><span class="property-type">objet</span></li>
+	</ul>
+	<p>Le <code>msg.method</code> ressemblera à ceci :</p>
+	<pre>
+{
+  "orderByChild": "nom",
+  "limitToFirst": 5,
+  "startAt": {
+    "value": "Alex",
+    "key": "nom"
+  }
+}</pre
+	>
+	<p>
+		Cliquer <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/firebase-in">ici</a>
 		pour en savoir plus sur l'utilisation de ce noeud.
 	</p>
 </script>

--- a/build/nodes/locales/fr/firebase-in.json
+++ b/build/nodes/locales/fr/firebase-in.json
@@ -9,6 +9,7 @@
       "name": "Nom"
     },
     "listenerType": {
+      "none": "- utiliser msg.listener -",
       "value": "Valeur",
       "child_added": "Enfant ajouté",
       "child_changed": "Enfant modifié",
@@ -38,6 +39,7 @@
       "child": "Clé de l'enfant"
     },
     "useConstraint": "Souhaitez-vous trier et ordonner vos données ?",
-    "addConstraint": "Ajouter une contrainte de requête"
+    "addConstraint": "Ajouter une contrainte de requête",
+    "passThrough": "Si un message arrive, transmettre le message ?"
   }
 }

--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -25,10 +25,10 @@ import {
 	Unsubscribe,
 } from "@gogovega/firebase-config-node/rtdb";
 import { ConfigNode, ServiceType } from "@gogovega/firebase-config-node/types";
-import { deepCopy, isFirebaseConfigNode } from "@gogovega/firebase-config-node/utils";
+import { deepCopy, Entry, isFirebaseConfigNode } from "@gogovega/firebase-config-node/utils";
 import { NodeAPI, NodeMessage } from "node-red";
 import {
-	ChildFieldType,
+	ChildField,
 	FirebaseConfig,
 	FirebaseGetConfig,
 	FirebaseGetNode,
@@ -42,7 +42,8 @@ import {
 	NodeConfig,
 	OutgoingMessage,
 	PathType,
-	ValueFieldType,
+	QueryConstraint,
+	ValueField,
 } from "./types";
 import { checkPath, checkPriority, printEnumKeys } from "./utils";
 
@@ -112,6 +113,30 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 		this.node.database?.removeStatusListener(this.node.id, this.serviceType, removed, done);
 	}
 
+	protected evaluateContextExpression(
+		msg: IncomingMessage,
+		value: string,
+		context: "flow" | "global"
+	): Promise<unknown> {
+		return new Promise((resolve, reject) => {
+			if (typeof msg !== "object" || !msg) throw new TypeError("The incoming message must be an object");
+			if (typeof value !== "string" || !value) throw new TypeError("The message property to evaluate must be a string");
+
+			const contextKey = this.RED.util.parseContextStore(value);
+
+			if (/\[msg\./.test(contextKey.key)) {
+				// The key has a nest msg. reference to evaluate first
+				contextKey.key = this.RED.util.normalisePropertyExpression(contextKey.key, msg, true);
+			}
+
+			return this.node.context()[context].get(contextKey.key, contextKey.store, (error, response) => {
+				if (error) return reject(error);
+
+				resolve(response);
+			});
+		});
+	}
+
 	/**
 	 * Evaluates the payload message to replace reserved keywords (`TIMESTAMP` and `INCREMENT`) with the corresponding server value.
 	 * @param payload The payload to be evaluated
@@ -154,17 +179,110 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 		}
 	}
 
-	protected getPathFromType(path?: string, type?: PathType, msg?: IncomingMessage) {
-		if (typeof path !== "string") throw new Error("The 'Path' field is undefined, please re-configure this node.");
+	protected getMessageProperty(msg: IncomingMessage, property: string): unknown {
+		if (typeof msg !== "object" || !msg) throw new TypeError("The incoming message must be an object");
+		if (typeof property !== "string" || !property)
+			throw new TypeError("The message property to evaluate must be a string");
+
+		return this.RED.util.getMessageProperty(msg, property);
+	}
+
+	protected getPath(msg: IncomingMessage | undefined, empty: true): string | undefined;
+	protected getPath(msg?: IncomingMessage | undefined, empty?: false): string;
+	protected getPath(msg?: IncomingMessage, empty?: boolean): string | undefined {
+		const path = this.getPathFromType(this.node.config.path, this.node.config.pathType, msg);
+
+		return checkPath(path, empty);
+	}
+
+	protected getPathFromType(value?: string, type?: PathType, msg?: IncomingMessage): unknown {
+		if (typeof value !== "string") throw new Error("The 'Path' field is undefined, please re-configure this node.");
+
+		// TODO: Remove Me
+		if (this.isFirebaseInNode(this.node) && type === undefined) type = "str";
+
+		if (!msg && type !== "str") throw new Error("Incoming message missing to evaluate the path");
 
 		switch (type) {
 			case "msg":
-				if (!msg) throw new Error("The incoming msg is undefined.");
-				return this.RED.util.getMessageProperty(msg, path);
+				return this.getMessageProperty(msg!, value);
 			case "str":
-				return path;
+				return value;
 			default:
-				throw new Error("pathType should be 'msg' or 'str', please re-configure this node.");
+				throw new Error(`The pathType (${type}) is invalid, please re-configure this node`);
+		}
+	}
+
+	/**
+	 * Gets the Query Constraints from the message received or from the node configuration.
+	 * Calls the `valueFromType` method to replace the value of the value field with its real value from the type.
+	 *
+	 * Example: user defined `msg.topic`, type is `msg`, saved value `topic` and real value is the content of `msg.topic`.
+	 *
+	 * @param msg The message received
+	 * @returns The Query Constraints
+	 */
+	protected async getQueryConstraints(msg?: IncomingMessage): Promise<Constraint> {
+		if (this.isFirebaseOutNode(this.node)) throw new Error("Constraints not available for modify method");
+
+		// @deprecated
+		if (msg?.method) return msg.method as unknown as object;
+		if (msg?.constraints) return msg.constraints;
+
+		// TODO: Change constraint to plural
+		const constraints = deepCopy(this.node.config.constraint ?? {});
+
+		if (typeof constraints !== "object") throw new Error("The 'Query Constraints' must be an object.");
+
+		// TODO: Use reduce to replace the loop
+		for (const value of Object.values(constraints) as Entry<QueryConstraint>) {
+			if (value && typeof value === "object") {
+				if (value.value === undefined) continue;
+				const newValue = await this.getValueFieldFromType(value.value, value.type, msg);
+
+				if (
+					typeof newValue !== "boolean" &&
+					typeof newValue !== "number" &&
+					typeof newValue !== "string" &&
+					newValue !== null
+				)
+					throw new TypeError("Values of Query Constraints must be a boolean, number, string or null!");
+
+				value.value = newValue;
+			}
+		}
+
+		return constraints;
+	}
+
+	/**
+	 * Find the value based on the received type. The `value` parameter received can either be the returned value or
+	 * be the key of a content in the message or in the context.
+	 *
+	 * Example: msg contains `msg.uid`, the value is `uid` and the type is `msg`. The returned value is the content of `msg.uid`.
+	 *
+	 * @param value The value of the Value Field
+	 * @param type The type of the Value Field
+	 * @param msg The message received
+	 * @returns The content of the value associated to the type
+	 */
+	protected async getValueFieldFromType(value: ValueField, type: ChildField, msg?: IncomingMessage): Promise<unknown> {
+		switch (type) {
+			case "bool":
+			case "date":
+			case "null":
+			case "num":
+			case "str":
+				return value;
+			case "msg":
+				if (!msg) throw new Error("Incoming message missing to evaluate the Query Constraints");
+				return this.getMessageProperty(msg, value as string);
+			case "flow":
+			case "global":
+				if (!msg) throw new Error("Incoming message missing to evaluate the Query Constraints");
+				return await this.evaluateContextExpression(msg, value as string, type);
+			default:
+				throw new Error(`The type of value field (${type}) is invalid, please re-configure this node.`);
 		}
 	}
 
@@ -258,8 +376,6 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 	 * @param time If defined, the status will be cleared (to current status) after `time` ms.
 	 */
 	protected setStatus(status: string = "", time?: number) {
-		//if (!this.rtdb) return;
-
 		// Clear the status to the current after ms
 		if (status && time) {
 			clearTimeout(this.errorTimeoutID);
@@ -284,42 +400,6 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 				this.node.status({ fill: "red", shape: "dot", text: status });
 				break;
 		}
-	}
-
-	/**
-	 * Find the value based on the received type. The `value` parameter received can either be the returned value or
-	 * be the key of a content in the message or in the context.
-	 *
-	 * Example: msg contains `msg.uid`, the value is `uid` and the type is `msg`. The returned value is the content of `msg.uid`.
-	 *
-	 * @param msg The message received
-	 * @param value The value of the Value Field
-	 * @param type The type of the Value Field
-	 * @returns The content of the value associated to the type
-	 */
-	protected valueFromType(msg: IncomingMessage, value: ValueFieldType, type: ChildFieldType): ValueFieldType {
-		if (type === "bool" || type === "date" || type === "null" || type === "num" || type === "str") return value;
-
-		if (type !== "flow" && type !== "global" && type !== "msg")
-			throw new Error("The type of value field should be 'flow', 'global' or 'msg', please re-configure this node.");
-
-		if (typeof value !== "string") throw new TypeError("The value field must be a string.");
-
-		if (type === "msg") return this.RED.util.getMessageProperty(msg, value);
-
-		const contextKey = this.RED.util.parseContextStore(value);
-
-		if (/\[msg\./.test(contextKey.key)) {
-			// The key has a nest msg. reference to evaluate first
-			contextKey.key = this.RED.util.normalisePropertyExpression(contextKey.key, msg, true);
-		}
-
-		const output = this.node.context()[type].get(contextKey.key, contextKey.store);
-
-		if (typeof output !== "boolean" && typeof output !== "number" && typeof output !== "string" && output !== null)
-			throw new TypeError("The context value used must be one of the types 'boolean', 'number', 'string' or 'null'");
-
-		return output;
 	}
 }
 
@@ -348,9 +428,9 @@ export class FirebaseGet extends Firebase<FirebaseGetNode> {
 	public get(msg: IncomingMessage, send: (msg: NodeMessage) => void, done: (error?: Error) => void): void {
 		(async () => {
 			try {
+				const path = this.getPath(msg, true);
+				const constraints = await this.getQueryConstraints(msg);
 				const msg2PassThrough = this.node.config.passThrough ? msg : undefined;
-				const constraints = this.getQueryConstraints(msg);
-				const path = this.getPath(msg);
 
 				if (!this.rtdb) return;
 
@@ -365,43 +445,6 @@ export class FirebaseGet extends Firebase<FirebaseGetNode> {
 				this.onError(error, done);
 			}
 		})();
-	}
-
-	private getPath(msg: IncomingMessage): string | undefined {
-		const { path, pathType } = this.node.config;
-		const pathGetted = this.getPathFromType(path, pathType, msg);
-
-		return checkPath(pathGetted, true);
-	}
-
-	/**
-	 * Gets the Query Constraints from the message received or from the node configuration.
-	 * Calls the `valueFromType` method to replace the value of the value field with its real value from the type.
-	 *
-	 * Example: user defined `msg.topic`, type is `msg`, saved value `topic` and real value is the content of `msg.topic`.
-	 *
-	 * @param msg The message received
-	 * @returns The Query Constraints
-	 */
-	private getQueryConstraints(msg: IncomingMessage): Constraint {
-		// @deprecated
-		if (msg.method) return msg.method as unknown as object;
-		if (msg.constraints) return msg.constraints;
-
-		// TODO: Change constraint to plural
-		const constraints = deepCopy(this.node.config.constraint ?? {});
-
-		if (typeof constraints !== "object") throw new Error("The 'Constraints' must be an object.");
-
-		// TODO: Add types
-		for (const value of Object.values(constraints)) {
-			if (value && typeof value === "object") {
-				if (value.value === undefined) continue;
-				value.value = this.valueFromType(msg, value.value, value.type);
-			}
-		}
-
-		return constraints;
 	}
 }
 
@@ -437,10 +480,6 @@ export class FirebaseIn extends Firebase<FirebaseInNode> {
 		if (typeof listener === "string" && listener in ListenerMap) return listener;
 
 		throw new Error(`The Listener should be one of ${printEnumKeys(ListenerMap)}. Please re-configure this node.`);
-	}
-
-	private getPath(): string | undefined {
-		return checkPath(this.node.config.path, true);
 	}
 
 	/**
@@ -501,13 +540,6 @@ export class FirebaseOut extends Firebase<FirebaseOutNode> {
 		if (typeof method !== "string") throw new Error("msg.method must be a string!");
 		if (method in QueryMethodMap) return method as QueryMethod;
 		throw new Error(`msg.method must be one of ${printEnumKeys(QueryMethodMap)}.`);
-	}
-
-	private getPath(msg: IncomingMessage): string {
-		const { path, pathType } = this.node.config;
-		const pathGetted = this.getPathFromType(path, pathType, msg);
-
-		return checkPath(pathGetted, false);
 	}
 
 	/**

--- a/src/lib/ondisconnect-node.ts
+++ b/src/lib/ondisconnect-node.ts
@@ -18,7 +18,7 @@ import { OnDisconnectQueryMethod, OnDisconnectQueryMethodMap } from "@gogovega/f
 import { NodeAPI } from "node-red";
 import { Firebase } from "./firebase-node";
 import { IncomingMessage, OnDisconnectConfig, OnDisconnectMessage, OnDisconnectNode, SendMsgEvent } from "./types";
-import { checkPath, checkPriority, printEnumKeys } from "./utils";
+import { checkPriority, printEnumKeys } from "./utils";
 
 /**
  * OnDisconnect Class
@@ -45,11 +45,7 @@ export class OnDisconnect extends Firebase<OnDisconnectNode> {
 	 */
 	private sendMsgOnDisconnect = () => this.sendMsgOnEvent("disconnect");
 
-	constructor(
-		node: OnDisconnectNode,
-		config: OnDisconnectConfig,
-		RED: NodeAPI
-	) {
+	constructor(node: OnDisconnectNode, config: OnDisconnectConfig, RED: NodeAPI) {
 		super(node, config, RED);
 	}
 
@@ -63,18 +59,6 @@ export class OnDisconnect extends Firebase<OnDisconnectNode> {
 		if (typeof method !== "string") throw new TypeError("msg.method must be a string!");
 		if (method in OnDisconnectQueryMethodMap) return method as OnDisconnectQueryMethod;
 		throw new Error(`msg.method must be one of ${printEnumKeys(OnDisconnectQueryMethodMap)}.`);
-	}
-
-	/**
-	 * Gets the path to the database from the node or message. Calls `checkPath` to check the path.
-	 * @param msg The message received
-	 * @returns The path checked to the database
-	 */
-	private getPath(msg: IncomingMessage): string {
-		const { path, pathType } = this.node.config;
-		const pathGetted = this.getPathFromType(path, pathType, msg);
-
-		return checkPath(pathGetted, false);
 	}
 
 	/**

--- a/src/lib/types/firebase-config.ts
+++ b/src/lib/types/firebase-config.ts
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 
+import { Listener, QueryMethod } from "@gogovega/firebase-config-node/rtdb";
 import { NodeDef } from "node-red";
-import { ListenerMap, QueryMethodMap } from "@gogovega/firebase-config-node/rtdb";
 
-export type ListenerType = keyof typeof ListenerMap;
+export type UID = string;
+
+export type ListenerType = Listener;
+
+export type Path = string;
 export type PathType = "msg" | "str";
+
 export type OutputType = "auto" | "string";
-export type QueryType = "none" | keyof typeof QueryMethodMap;
 
-export type ValueFieldType = number | string | boolean | null;
-export type ChildFieldType = "bool" | "date" | "flow" | "global" | "msg" | "null" | "num" | "str";
+export type ChildField = "bool" | "date" | "flow" | "global" | "msg" | "null" | "num" | "str";
+export type ValueField = number | string | boolean | null;
 
-interface RangeQueryType {
+export interface RangeQuery {
 	key?: string;
-	value: ValueFieldType;
-	type: ChildFieldType;
+	value: ValueField;
+	type: ChildField;
 }
 
 export interface QueryConstraint {
@@ -38,37 +42,34 @@ export interface QueryConstraint {
 	limitToFirst?: number;
 	limitToLast?: number;
 	orderByChild?: string;
-	endAt?: RangeQueryType;
-	endBefore?: RangeQueryType;
-	equalTo?: RangeQueryType;
-	startAfter?: RangeQueryType;
-	startAt?: RangeQueryType;
+	endAt?: RangeQuery;
+	endBefore?: RangeQuery;
+	equalTo?: RangeQuery;
+	startAfter?: RangeQuery;
+	startAt?: RangeQuery;
 }
 
-type BaseConfig = NodeDef & {
-	database: string;
+export type BaseConfig = NodeDef & {
+	database: UID;
+	path?: Path;
+	pathType?: PathType;
 };
 
 export type FirebaseGetConfig = BaseConfig & {
 	constraint?: QueryConstraint;
 	outputType?: OutputType;
 	passThrough?: boolean;
-	path?: string;
-	pathType?: PathType;
 };
 
 export type FirebaseInConfig = BaseConfig & {
 	constraint?: QueryConstraint;
 	listenerType?: ListenerType;
 	outputType?: OutputType;
-	path?: string;
 };
 
 export type FirebaseOutConfig = BaseConfig & {
-	path?: string;
-	pathType?: PathType;
 	priority?: number;
-	queryType?: QueryType;
+	queryType?: QueryMethod | "none";
 };
 
 export type FirebaseConfig = FirebaseGetConfig | FirebaseInConfig | FirebaseOutConfig;

--- a/src/lib/types/firebase-config.ts
+++ b/src/lib/types/firebase-config.ts
@@ -19,7 +19,7 @@ import { NodeDef } from "node-red";
 
 export type UID = string;
 
-export type ListenerType = Listener;
+export type ListenerType = Listener | "none";
 
 export type Path = string;
 export type PathType = "msg" | "str";
@@ -65,6 +65,7 @@ export type FirebaseInConfig = BaseConfig & {
 	constraint?: QueryConstraint;
 	listenerType?: ListenerType;
 	outputType?: OutputType;
+	passThrough?: boolean;
 };
 
 export type FirebaseOutConfig = BaseConfig & {

--- a/src/lib/types/firebase-node.ts
+++ b/src/lib/types/firebase-node.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Node, NodeMessage, NodeMessageInFlow } from "node-red";
-import { ConfigNode } from "@gogovega/firebase-config-node/types";
 import { Constraint, QueryMethod } from "@gogovega/firebase-config-node/rtdb";
+import { ConfigNode } from "@gogovega/firebase-config-node/types";
+import { Node, NodeMessage, NodeMessageInFlow } from "node-red";
 import { FirebaseGetConfig, FirebaseInConfig, FirebaseOutConfig } from "./firebase-config";
 
 export enum QueryConstraintMap {
@@ -37,7 +37,7 @@ type Priority = number | string;
 
 export interface IncomingMessage extends NodeMessageInFlow {
 	constraints?: Constraint;
-	method?: "none" | QueryMethod;
+	method?: QueryMethod;
 	priority?: Priority;
 }
 

--- a/src/lib/types/firebase-node.ts
+++ b/src/lib/types/firebase-node.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Constraint, QueryMethod } from "@gogovega/firebase-config-node/rtdb";
+import { Constraint, Listener, QueryMethod } from "@gogovega/firebase-config-node/rtdb";
 import { ConfigNode } from "@gogovega/firebase-config-node/types";
 import { Node, NodeMessage, NodeMessageInFlow } from "node-red";
 import { FirebaseGetConfig, FirebaseInConfig, FirebaseOutConfig } from "./firebase-config";
@@ -37,6 +37,7 @@ type Priority = number | string;
 
 export interface IncomingMessage extends NodeMessageInFlow {
 	constraints?: Constraint;
+	listener?: Listener;
 	method?: QueryMethod;
 	priority?: Priority;
 }

--- a/src/lib/types/ondisconnect-config.ts
+++ b/src/lib/types/ondisconnect-config.ts
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import { OnDisconnectQueryMethodMap } from "@gogovega/firebase-config-node/rtdb";
-import { NodeDef } from "node-red";
+import { OnDisconnectQueryMethod } from "@gogovega/firebase-config-node/rtdb";
+import { BaseConfig } from "./firebase-config";
 
-type PathType = "msg" | "str";
-type QueryType = "msg" | "none" | keyof typeof OnDisconnectQueryMethodMap;
+type QueryType = OnDisconnectQueryMethod | "msg" | "none";
 type SendMsgEvent = "" | "onConnected" | "onDisconnect" | "onConnected,onDisconnect";
 
-export type OnDisconnectConfig = NodeDef & {
-	database: string;
-	path?: string;
-	pathType?: PathType;
+export type OnDisconnectConfig = BaseConfig & {
 	queryType?: QueryType;
 	sendMsgEvent?: SendMsgEvent;
 };

--- a/src/lib/types/ondisconnect-node.ts
+++ b/src/lib/types/ondisconnect-node.ts
@@ -26,6 +26,6 @@ export interface OnDisconnectMessage extends NodeMessage {
 	topic: string;
 }
 
-export type OnDisconnectNode = FirebaseBaseNode & {
+export interface OnDisconnectNode extends FirebaseBaseNode {
 	config: OnDisconnectConfig;
-};
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,19 +27,9 @@ function printEnumKeys(obj: object) {
  * @param empty Can the path be empty? Default: `false`
  * @returns The path checked to the database
  */
-function checkPath(path: unknown, empty: true): string | undefined;
-
-/**
- * Checks path to match Firebase rules. Throws an error if does not match.
- * @param path The path to check
- * @param empty Can the path be empty? Default: `false`
- * @returns The path checked to the database
- */
 function checkPath(path: unknown, empty?: false): string;
-
-/**
- * @overload
- */
+function checkPath(path: unknown, empty: true): string | undefined;
+function checkPath(path: unknown, empty?: boolean): string | undefined;
 function checkPath(path: unknown, empty?: boolean): string | undefined {
 	if (empty && path === "") return;
 	if (empty && path === undefined) return;

--- a/src/nodes/firebase-in.ts
+++ b/src/nodes/firebase-in.ts
@@ -27,6 +27,8 @@ module.exports = function (RED: NodeAPI) {
 		firebase.attachStatusListener();
 		firebase.subscribe();
 
+		this.on("input", (msg, send, done) => firebase.subscribe(msg, send, done));
+
 		this.on("close", (removed: boolean, done: () => void) => {
 			firebase.unsubscribe();
 			firebase.detachStatusListener(removed, done);


### PR DESCRIPTION
Support to dynamically set `Firebase-in` node properties:

- Listener
- Path
- Query Constraints

i.e. This node can be setted to have input and node properties set dynamically from the properties of an incoming message.