### PR TITLE
Refactor: Use resources for editor to remove duplicates

### DIFF
--- a/build/nodes/firebase-get.html
+++ b/build/nodes/firebase-get.html
@@ -15,9 +15,13 @@
 -->
 
 <script type="text/javascript">
+	"use strict";
+
 	(function () {
-		let queryConstraintFieldType = ["endAt", "endBefore", "equalTo", "limitToFirst", "limitToLast", "orderByChild", "orderByKey", "orderByPriority", "orderByValue", "startAfter", "startAt"];
-		let translationInitialized = false;
+		const editableConstraintsList = FirebaseQueryConstraintsContainer.editableConstraintsList.create();
+		const { isConstraintsValid } = FirebaseQueryConstraintsContainer.validators;
+		const { typedPathField, validators } = FirebaseUI;
+		const i18n = (key) => FirebaseUI._(key, "firebase-get");
 
 		RED.nodes.registerType("firebase-get", {
 			align: "left",
@@ -25,13 +29,13 @@
 			color: "#e2a12b",
 			defaults: {
 				name: { value: "" },
-				constraint: { value: {}, validate: isConstraintValid },
+				constraint: { value: {}, label: i18n("label.constraint"), validate: isConstraintsValid() },
 				database: { value: "", type: "firebase-config" },
-				outputType: { value: "auto", validate: RED.validators.regex(/^(auto|string)$/) },
-				passThrough: { value: false },
-				path: { value: "topic" },
-				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
-				useConstraint: { value: false },
+				outputType: { value: "auto", label: i18n("label.output"), validate: validators.outputType() },
+				passThrough: { value: false, label: i18n("label.passThrough") },
+				path: { value: "topic", label: i18n("label.path"), validate: validators.typedInput("pathType", { blankAllowed: true }) },
+				pathType: { value: "msg", label: i18n("label.path"), validate: validators.pathType() },
+				useConstraint: { value: false, label: i18n("label.sortData") },
 			},
 			inputs: 1,
 			outputs: 1,
@@ -45,245 +49,13 @@
 				return this.name ? "node_label_italic" : "";
 			},
 			oneditprepare: function () {
-				const constraintContainer = $("#node-input-constraint-container");
-				const useConstraint = $("#node-input-useConstraint");
-				const node = this;
+				editableConstraintsList.build(this);
 
-				$("#node-input-path").typedInput({
-					typeField: "#node-input-pathType",
-					types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
-				});
-
-				if (!translationInitialized) {
-					translationInitialized = true;
-					queryConstraintFieldType = queryConstraintFieldType.map((fieldName) => (
-						{ value: fieldName, label: node._(`firebase-get.constraint.${fieldName}`) }
-					));
-				}
-
-				constraintContainer.css({ "min-height": "150px", "min-width": "300px" }).editableList({
-					addButton: node._("firebase-get.addConstraint"),
-					addItem: addItem.bind(node),
-					removable: true,
-					sortable: true,
-				});
-
-				useConstraint.on("change", useConstraintHandler.bind(node));
+				const pathField = typedPathField.create(true);
 			},
-			oneditsave: saveItems,
+			oneditsave: () => editableConstraintsList.saveItems(),
+			oneditresize: (size) => editableConstraintsList.reSize(size),
 		});
-
-		function addItem(container, index, data) {
-			const id = Math.floor((0x99999 - 0x10000) * Math.random()).toString();
-
-			const HTMLBody = `
-				<div style="flex-grow:1;">
-					<div style="width:45%; vertical-align:top; display:inline-block;">
-						<input type="text" id="node-input-constraintType-case-${id}" style="width:100%; text-align:center;">
-					</div>
-					<div style="width:calc(54% - 5px); margin-left:5px; vertical-align:top; display:inline-block;">
-						<div class="container-row-value-case-${id}">
-							<input type="text" id="node-input-value-case-${id}" style="width:100%;" placeholder="${this._("firebase-get.placeholder.value")}" />
-							<input type="hidden" id="node-input-valueType-case-${id}" />
-						</div>
-						<input type="text" id="node-input-child-case-${id}" style="width:100%;" placeholder="${this._("firebase-get.placeholder.child")}" />
-					</div>
-				</div>`;
-
-			container.css({
-				overflow: "auto",
-				whiteSpace: "normal",
-				display: "flex",
-				"align-items": "center",
-			});
-
-			$(container).html(HTMLBody);
-			const constraintType = $(container).find(`#node-input-constraintType-case-${id}`);
-			const valueContainer = $(container).find(`.container-row-value-case-${id}`);
-			const valueField = $(container).find(`#node-input-value-case-${id}`);
-			const childField = $(container).find(`#node-input-child-case-${id}`);
-
-			valueField.typedInput({ default: "num", typeField: `#node-input-valueType-case-${id}`, types: ["num"] });
-			childField
-				.typedInput({ default: "str", types: [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: (c) => isChildValid(c, constraintType.val()) }] })
-				.typedInput("hide");
-
-			constraintType
-				.typedInput({ types: [{ options: queryConstraintFieldType }] })
-				.on("change", (_event, _type, value) => updateTypeOfTypedInput(valueField, valueContainer, childField, value))
-				.typedInput("value", "limitToLast");
-
-			if (Array.isArray(data)) {
-				const [key, value] = data;
-
-				constraintType.typedInput("value", key);
-
-				if (value && typeof value === "object") {
-					valueField.typedInput("value", value.value?.toString() ?? "");
-					valueField.typedInput("type", value.type ?? "str");
-					childField.typedInput("value", value.key ?? "");
-				} else {
-					if (key === "orderByChild") {
-						valueField.typedInput("value", "");
-						childField.typedInput("value", value ?? "");
-					} else {
-						valueField.typedInput("value", value ?? "");
-						childField.typedInput("value", "");
-					}
-				}
-
-				data = {};
-				$(container).data("data", data);
-			}
-
-			data.id = id;
-			data.index = index;
-		}
-
-		function compare(a, b) {
-			return a.index - b.index;
-		}
-
-		function isChildValid(child, constraintType) {
-			// orderByChild cannot be empty!
-			const empty = constraintType === "orderByChild" ? false : true;
-
-			if ((!child && !empty) || typeof child !== "string") return false;
-			if (child?.match(/^\s|[.#$\[\]]/g)) return false;
-			return true;
-		}
-
-		function isConstraintValid(constraint = {}, opt) {
-			if (typeof constraint !== "object") return false;
-
-			for (let [k, v] of Object.entries(constraint)) {
-				if (!queryConstraintFieldType.some((q) => q.value === k || q === k)) return false;
-				if (v === null) v = {};
-				if (v.type && v.type.match(/^(num|date)$/) && (typeof v.value !== "number" || Number.isNaN(v.value))) return false;
-				if (v.type === "bool" && typeof v.value !== "boolean") return false;
-				if (v.type === "json" && typeof v.value !== "object") return false;
-				if (v.type === "str" && typeof v.value !== "string") return false;
-				if (k === "limitToFirst" && (!Number.isInteger(Number(v)) || Number(v) <= 0)) return false;
-				if (k === "limitToLast" && (!Number.isInteger(Number(v)) || Number(v) <= 0)) return false;
-				if (k === "orderByChild" && !isChildValid(v, k)) return false;
-				if (v.key && !isChildValid(v.key, k)) return false;
-			}
-
-			return true;
-		}
-
-		function isPathValid(path) {
-			if (typeof path !== "string") return false;
-			if (path.match(/^\s|[.#$\[\]]/g)) return false;
-			return true;
-		}
-
-		function saveItems() {
-			const container = $("#node-input-constraint-container").editableList("items").sort(compare);
-			const node = this;
-
-			node.constraint = {};
-
-			container.each(function () {
-				const id = $(this).data("data")?.id;
-				const constraintType = $(this).find(`#node-input-constraintType-case-${id}`).val();
-				const value = $(this).find(`#node-input-value-case-${id}`).val();
-				const child = $(this).find(`#node-input-child-case-${id}`).val() || undefined;
-				const type = $(this).find(`#node-input-valueType-case-${id}`).val();
-
-				switch (constraintType) {
-					case "endAt":
-					case "endBefore":
-					case "equalTo":
-					case "startAfter":
-					case "startAt": {
-						let valueParsed =
-							type === "date" ? Date.now() :
-							type === "null" ? null :
-							type === "num" ? Number(value) :
-							type === "bool" ? (value === "true" ? true : false) :
-							value;
-
-						if (type === "num" && Number.isNaN(valueParsed)) {
-							RED.notify("Query Constraints: Setted value is not a number!", "error");
-							valueParsed = value;
-						}
-
-						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
-						break;
-					}
-					case "limitToFirst":
-					case "limitToLast": {
-						let valueParsed = Number(value);
-						if (!Number.isInteger(valueParsed) || valueParsed <= 0) {
-							RED.notify("Query Constraints: Setted value is not an integrer > 0!", "error");
-							valueParsed = value;
-						}
-
-						node.constraint[constraintType] = valueParsed;
-						break;
-					}
-					case "orderByChild":
-						node.constraint[constraintType] = child || null;
-						break;
-					case "orderByKey":
-					case "orderByPriority":
-					case "orderByValue":
-						node.constraint[constraintType] = null;
-						break;
-				}
-			});
-		}
-
-		function updateTypeOfTypedInput(value, valueContainer, child, key) {
-			// Initial state
-			value.typedInput("show");
-			valueContainer.css("padding-bottom", "0px");
-			child.typedInput("hide");
-			child.typedInput("value", "");
-
-			switch (key) {
-				case "endAt":
-				case "endBefore":
-				case "equalTo":
-				case "startAfter":
-				case "startAt":
-					value.typedInput("types", ["flow", "global", "msg", "bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
-					valueContainer.css("padding-bottom", "5px");
-					child.typedInput("show");
-					break;
-				case "limitToFirst":
-				case "limitToLast":
-					value.typedInput("types", ["num"]);
-					break;
-				case "orderByChild":
-					value.typedInput("hide");
-					child.typedInput("show");
-					break;
-				case "orderByKey":
-				case "orderByPriority":
-				case "orderByValue":
-					value.typedInput("hide");
-					break;
-			}
-		}
-
-		function useConstraintHandler() {
-			const constraintContainer = $("#node-input-constraint-container");
-			const useConstraint = $("#node-input-useConstraint");
-
-			if (useConstraint.prop("checked") === true) {
-				let constraint = Object.entries(this.constraint || {});
-
-				if (constraint.length === 0) constraint = [["limitToLast", 5]];
-
-				constraint.forEach((item) => constraintContainer.editableList("addItem", item));
-				$(".form-row-constraint").show();
-			} else {
-				$(".form-row-constraint").hide();
-				constraintContainer.editableList("empty");
-			}
-		}
 	})();
 </script>
 
@@ -299,8 +71,8 @@
 		<span data-i18n="firebase-get.useConstraint"></span>
 	</div>
 
-	<div class="form-row form-row-constraint node-input-constraint-container-row">
-		<ol id="node-input-constraint-container"></ol>
+	<div class="form-row node-input-constraints-container-row">
+		<ol id="node-input-constraints-container"></ol>
 	</div>
 
 	<div class="form-row">

--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -15,9 +15,13 @@
 -->
 
 <script type="text/javascript">
+	"use strict";
+
 	(function () {
-		let queryConstraintFieldType = ["endAt", "endBefore", "equalTo", "limitToFirst", "limitToLast", "orderByChild", "orderByKey", "orderByPriority", "orderByValue", "startAfter", "startAt"];
-		let translationInitialized = false;
+		const editableConstraintsList = FirebaseQueryConstraintsContainer.editableConstraintsList.create();
+		const { isConstraintsValid } = FirebaseQueryConstraintsContainer.validators;
+		const { typedPathField, validators } = FirebaseUI;
+		const i18n = (key) => FirebaseUI._(key, "firebase-in");
 
 		RED.nodes.registerType("firebase-in", {
 			align: "left",
@@ -25,15 +29,15 @@
 			color: "#e2a12b",
 			defaults: {
 				name: { value: "" },
-				constraint: { value: {}, validate: isConstraintValid },
+				constraint: { value: {}, label: i18n("label.constraint"), validate: isConstraintsValid() },
 				database: { value: "", type: "firebase-config" },
 				inputs: { value: 0 },
-				listenerType: { value: "value", validate: RED.validators.regex(/^(none|value|child_added|child_changed|child_moved|child_removed)$/) },
-				outputType: { value: "auto", validate: RED.validators.regex(/^(auto|string)$/) },
-				passThrough: { value: false },
-				path: { value: "test/stream", validate: (v) => !v.match(/^\s+|[.#$\[\]]$/g) },
-				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
-				useConstraint: { value: false },
+				listenerType: { value: "value", label: i18n("label.listener"), validate: validators.listenerType() },
+				outputType: { value: "auto", label: i18n("label.output"), validate: validators.outputType() },
+				passThrough: { value: false, label: i18n("label.passThrough") },
+				path: { value: "test/stream", label: i18n("label.path"), validate: validators.typedInput("pathType", { blankAllowed: true }) },
+				pathType: { value: "str", label: i18n("label.path"), validate: validators.pathType() },
+				useConstraint: { value: false, label: i18n("label.sortData") },
 			},
 			inputs: 0,
 			outputs: 1,
@@ -46,259 +50,21 @@
 				return this.name ? "node_label_italic" : "";
 			},
 			oneditprepare: function () {
-				const constraintContainer = $("#node-input-constraint-container");
-				const useConstraint = $("#node-input-useConstraint");
-				const node = this;
+				editableConstraintsList.build(this);
 
-				if (!translationInitialized) {
-					translationInitialized = true;
-					queryConstraintFieldType = queryConstraintFieldType.map((fieldName) => (
-						{ value: fieldName, label: node._(`firebase-in.constraint.${fieldName}`) }
-					));
-				}
+				const pathField = typedPathField.create(true);
+				const listenerType = $("#node-input-listenerType");
 
-				$("#node-input-path").typedInput({
-					typeField: "#node-input-pathType",
-					types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
-				});
-
-				$("#node-input-listenerType").on("change", listenerTypeHandler);
-
-				constraintContainer.css({ "min-height": "150px", "min-width": "300px" }).editableList({
-					addButton: node._("firebase-in.addConstraint"),
-					addItem: addItem.bind(node),
-					removable: true,
-					sortable: true,
-				});
-
-				useConstraint.on("change", useConstraintHandler.bind(node));
+				listenerType.on("change", () => pathField.updateTypesToStaticOrDynamic(listenerType.val() === "none"));
 			},
 			oneditsave: function () {
-				saveItems.call(this);
-				
+				editableConstraintsList.saveItems();
+
 				const inputs = $("#node-input-listenerType").val() === "none" ? 1 : 0;
 				$("#node-input-inputs").val(inputs);
 			},
+			oneditresize: (size) => editableConstraintsList.reSize(size),
 		});
-
-		function addItem(container, index, data) {
-			const id = Math.floor((0x99999 - 0x10000) * Math.random()).toString();
-
-			const HTMLBody = `
-				<div style="flex-grow:1;">
-					<div style="width:45%; vertical-align:top; display:inline-block;">
-						<input type="text" id="node-input-constraintType-case-${id}" style="width:100%; text-align:center;">
-					</div>
-					<div style="width:calc(54% - 5px); margin-left:5px; vertical-align:top; display:inline-block;">
-						<div class="container-row-value-case-${id}">
-							<input type="text" id="node-input-value-case-${id}" style="width:100%;" placeholder="${this._("firebase-in.placeholder.value")}" />
-							<input type="hidden" id="node-input-valueType-case-${id}" />
-						</div>
-						<input type="text" id="node-input-child-case-${id}" style="width:100%;" placeholder="${this._("firebase-in.placeholder.child")}" />
-					</div>
-				</div>`;
-
-			container.css({
-				overflow: "auto",
-				whiteSpace: "normal",
-				display: "flex",
-				"align-items": "center",
-			});
-
-			$(container).html(HTMLBody);
-			const constraintType = $(container).find(`#node-input-constraintType-case-${id}`);
-			const valueContainer = $(container).find(`.container-row-value-case-${id}`);
-			const valueField = $(container).find(`#node-input-value-case-${id}`);
-			const childField = $(container).find(`#node-input-child-case-${id}`);
-
-			valueField.typedInput({ default: "num", typeField: `#node-input-valueType-case-${id}`, types: ["num"] });
-			childField
-				.typedInput({ default: "str", types: [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: (c) => isChildValid(c, constraintType.val()) }] })
-				.typedInput("hide");
-
-			constraintType
-				.typedInput({ types: [{ options: queryConstraintFieldType }] })
-				.on("change", (_event, _type, value) => updateTypeOfTypedInput(valueField, valueContainer, childField, value))
-				.typedInput("value", "limitToLast");
-
-			if (Array.isArray(data)) {
-				const [key, value] = data;
-
-				constraintType.typedInput("value", key);
-
-				if (value && typeof value === "object") {
-					valueField.typedInput("value", value.value?.toString() ?? "");
-					valueField.typedInput("type", value.type ?? "str");
-					childField.typedInput("value", value.key ?? "");
-				} else {
-					if (key === "orderByChild") {
-						valueField.typedInput("value", "");
-						childField.typedInput("value", value ?? "");
-					} else {
-						valueField.typedInput("value", value ?? "");
-						childField.typedInput("value", "");
-					}
-				}
-
-				data = {};
-				$(container).data("data", data);
-			}
-
-			data.id = id;
-			data.index = index;
-		}
-
-		function compare(a, b) {
-			return a.index - b.index;
-		}
-
-		function isChildValid(child, constraintType) {
-			// orderByChild cannot be empty!
-			const empty = constraintType === "orderByChild" ? false : true;
-
-			if ((!child && !empty) || typeof child !== "string") return false;
-			if (child?.match(/^\s|[.#$\[\]]/g)) return false;
-			return true;
-		}
-
-		function isConstraintValid(constraint = {}, opt) {
-			if (typeof constraint !== "object") return false;
-
-			for (let [k, v] of Object.entries(constraint)) {
-				if (!queryConstraintFieldType.some((q) => q.value === k || q === k)) return false;
-				if (v === null) v = {};
-				if (v.type && v.type.match(/^(num|date)$/) && (typeof v.value !== "number" || Number.isNaN(v.value))) return false;
-				if (v.type === "bool" && typeof v.value !== "boolean") return false;
-				if (v.type === "json" && typeof v.value !== "object") return false;
-				if (v.type === "str" && typeof v.value !== "string") return false;
-				if (k === "limitToFirst" && (!Number.isInteger(Number(v)) || Number(v) <= 0)) return false;
-				if (k === "limitToLast" && (!Number.isInteger(Number(v)) || Number(v) <= 0)) return false;
-				if (k === "orderByChild" && !isChildValid(v, k)) return false;
-				if (v.key && !isChildValid(v.key, k)) return false;
-			}
-
-			return true;
-		}
-
-		function isPathValid(path) {
-			if (typeof path !== "string") return false;
-			if (path.match(/^\s|[.#$\[\]]/g)) return false;
-			return true;
-		}
-
-		function listenerTypeHandler() {
-			const defaultTypes = ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }]
-			const types = $("#node-input-listenerType").val() === "none" ? defaultTypes : [defaultTypes[1]];
-
-			$("#node-input-path").typedInput("types", types);
-		}
-
-		function saveItems() {
-			const container = $("#node-input-constraint-container").editableList("items").sort(compare);
-			const node = this;
-
-			node.constraint = {};
-
-			container.each(function () {
-				const id = $(this).data("data").id;
-				const constraintType = $(this).find(`#node-input-constraintType-case-${id}`).typedInput("value");
-				const value = $(this).find(`#node-input-value-case-${id}`).val();
-				const child = $(this).find(`#node-input-child-case-${id}`).val() || undefined;
-				const type = $(this).find(`#node-input-valueType-case-${id}`).val();
-
-				switch (constraintType) {
-					case "endAt":
-					case "endBefore":
-					case "equalTo":
-					case "startAfter":
-					case "startAt": {
-						let valueParsed =
-							type === "date" ? Date.now() :
-							type === "null" ? null :
-							type === "num" ? Number(value) :
-							type === "bool" ? (value === "true" ? true : false) :
-							value;
-
-						if (type === "num" && Number.isNaN(valueParsed)) {
-							RED.notify("Query Constraints: Setted value is not a number!", "error");
-							valueParsed = value;
-						}
-
-						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
-						break;
-					}
-					case "limitToFirst":
-					case "limitToLast": {
-						let valueParsed = Number(value);
-						if (!Number.isInteger(valueParsed) || valueParsed <= 0) {
-							RED.notify("Query Constraints: Setted value is not an integrer > 0!", "error");
-							valueParsed = value;
-						}
-
-						node.constraint[constraintType] = valueParsed;
-						break;
-					}
-					case "orderByChild":
-						node.constraint[constraintType] = child || null;
-						break;
-					case "orderByKey":
-					case "orderByPriority":
-					case "orderByValue":
-						node.constraint[constraintType] = null;
-						break;
-				}
-			});
-		}
-
-		function updateTypeOfTypedInput(value, valueContainer, child, key) {
-			// Initial state
-			value.typedInput("show");
-			valueContainer.css("padding-bottom", "0px");
-			child.typedInput("hide");
-			child.typedInput("value", "");
-
-			switch (key) {
-				case "endAt":
-				case "endBefore":
-				case "equalTo":
-				case "startAfter":
-				case "startAt":
-					value.typedInput("types", ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
-					valueContainer.css("padding-bottom", "5px");
-					child.typedInput("show");
-					break;
-				case "limitToFirst":
-				case "limitToLast":
-					value.typedInput("types", ["num"]);
-					break;
-				case "orderByChild":
-					value.typedInput("hide");
-					child.typedInput("show");
-					break;
-				case "orderByKey":
-				case "orderByPriority":
-				case "orderByValue":
-					value.typedInput("hide");
-					break;
-			}
-		}
-
-		function useConstraintHandler() {
-			const constraintContainer = $("#node-input-constraint-container");
-			const useConstraint = $("#node-input-useConstraint");
-
-			if (useConstraint.prop("checked") === true) {
-				let constraint = Object.entries(this.constraint || {});
-
-				if (constraint.length === 0) constraint = [["limitToLast", 5]];
-
-				constraint.forEach((item) => constraintContainer.editableList("addItem", item));
-				$(".form-row-constraint").show();
-			} else {
-				$(".form-row-constraint").hide();
-				constraintContainer.editableList("empty");
-			}
-		}
 	})();
 </script>
 
@@ -327,8 +93,8 @@
 		<span data-i18n="firebase-in.useConstraint"></span>
 	</div>
 
-	<div class="form-row form-row-constraint node-input-constraint-container-row">
-		<ol id="node-input-constraint-container"></ol>
+	<div class="form-row node-input-constraints-container-row">
+		<ol id="node-input-constraints-container"></ol>
 	</div>
 
 	<div class="form-row">

--- a/build/nodes/firebase-out.html
+++ b/build/nodes/firebase-out.html
@@ -15,62 +15,64 @@
 -->
 
 <script type="text/javascript">
-	RED.nodes.registerType("firebase-out", {
-		align: "right",
-		category: "Firebase",
-		color: "#e2a12b",
-		defaults: {
-			name: { value: "" },
-			database: { value: "", type: "firebase-config" },
-			path: { value: "topic" },
-			pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
-			priority: { value: 1 },
-			queryType: { value: "none", validate: RED.validators.regex(/^(none|set|push|update|remove|setPriority|setWithPriority)$/) },
-		},
-		inputs: 1,
-		outputs: 0,
-		icon: "firebase.png",
-		paletteLabel: "Firebase out",
-		label: function () {
-			const query = this.queryType !== "none" ? this.queryType.toUpperCase() : "";
-			const path = this.pathType === "msg" ? "" : this.path;
-			const name = query.concat(query ? " " : "", path);
-			return this.name || name || "Firebase out";
-		},
-		labelStyle: function () {
-			return this.name ? "node_label_italic" : "";
-		},
-		oneditprepare: function () {
-			$("#node-input-path").typedInput({
-				typeField: $("#node-input-pathType"),
-				types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
-			});
+	"use strict";
 
-			$("#node-input-priority").typedInput({
-				typeField: $("#node-input-priorityType"),
-				types: ["num"],
-			});
+	(function () {
+		const { typedPathField, validators } = FirebaseUI;
+		const i18n = (key) => FirebaseUI._(key, "firebase-out");
 
-			const queryType = $("#node-input-queryType");
-			queryType.on("change", () => {
-				switch (queryType.val()) {
-					case "setPriority":
-					case "setWithPriority":
-						$(".form-row-priority").show();
-						break;
-					default:
-						$(".form-row-priority").hide();
-						break;
-				}
-			});
-		},
-	});
+		RED.nodes.registerType("firebase-out", {
+			align: "right",
+			category: "Firebase",
+			color: "#e2a12b",
+			defaults: {
+				name: { value: "" },
+				database: { value: "", type: "firebase-config" },
+				path: { value: "topic", label: i18n("label.path"), validate: validators.typedInput("pathType") },
+				pathType: { value: "msg", label: i18n("label.path"), validate: validators.pathType() },
+				priority: { value: "1", label: i18n("label.priority"), validate: validators.priority() },
+				queryType: { value: "none", label: i18n("label.query"), validate: validators.queryType() },
+			},
+			inputs: 1,
+			outputs: 0,
+			icon: "firebase.png",
+			paletteLabel: "Firebase out",
+			label: function () {
+				const query = this.queryType !== "none" ? this.queryType.toUpperCase() : "";
+				const path = this.pathType === "msg" ? "" : this.path;
+				const name = query.concat(query ? " " : "", path);
+				return this.name || name || "Firebase out";
+			},
+			labelStyle: function () {
+				return this.name ? "node_label_italic" : "";
+			},
+			oneditprepare: function () {
+				const pathField = typedPathField.create(false);
+				const priorityField = $("#node-input-priority");
+				const queryType = $("#node-input-queryType");
 
-	function isPathValid(x) {
-		if (!x || typeof x !== "string") return false;
-		if (x.match(/^\s|[.#$\[\]]/g)) return false;
-		return true;
-	}
+				priorityField.typedInput({
+					default: "num",
+					types: [{ value: "num", label: "number", icon: "red/images/typedInput/09.svg", validate: validators.priority() }],
+				});
+
+				// REMOVE ME
+				if (priorityField.val() === "") priorityField.typedInput("value", "1");
+
+				queryType.on("change", () => {
+					switch (queryType.val()) {
+						case "setPriority":
+						case "setWithPriority":
+							$(".form-row-priority").show();
+							break;
+						default:
+							$(".form-row-priority").hide();
+							break;
+					}
+				});
+			},
+		});
+	})();
 </script>
 
 <script type="text/html" data-template-name="firebase-out">

--- a/build/nodes/load-config.html
+++ b/build/nodes/load-config.html
@@ -1,0 +1,19 @@
+<!--
+  Copyright 2022-2023 Gauthier Dandele
+
+  Licensed under the MIT License,
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://opensource.org/licenses/MIT.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- Load Scripts -->
+<script type="text/javascript" src="resources/@gogovega/node-red-contrib-firebase-realtime-database/common.js"></script>
+<script type="text/javascript" src="resources/@gogovega/node-red-contrib-firebase-realtime-database/constraints-container.js"></script>

--- a/build/nodes/locales/de/firebase-get.json
+++ b/build/nodes/locales/de/firebase-get.json
@@ -3,31 +3,18 @@
     "label": {
       "database": "Datenbank",
       "sortData": "Daten sortieren?",
+      "constraint": "Abfrageeinschränkungen",
       "path": "Pfad",
       "output": "Ausgabe",
+      "passThrough": "Durchreichen",
       "name": "Name"
-    },
-    "constraint": {
-      "orderByChild": "Nach Kindern sortieren",
-      "orderByKey": "Nach Schlüssel sortieren",
-      "orderByPriority": "Nach Priorität sortieren",
-      "orderByValue": "Nach Wert sortieren",
-      "limitToFirst": "Zum Anfang begrenzen",
-      "limitToLast": "Zum Ende begrenzen",
-      "endAt": "Ende bei",
-      "endBefore": "Ende vor",
-      "equalTo": "gleich zu",
-      "startAfter": "Starte nach",
-      "startAt": "Starte bei"
     },
     "outputType": {
       "auto": "Automatisch erkennen",
       "string": "eine Zeichenkette"
     },
     "placeholder": {
-      "name": "Name",
-      "value": "Wert",
-      "child": "Kind schlüssel"
+      "name": "Name"
     },
     "tips": {
       "tips": "<strong>Tips</strong>:",
@@ -35,7 +22,6 @@
       "tip1": "Wenn <code>msg.method</code> gesetzt ist, werden die im Knoten definierten Abfrageeinschränkungen durch die Nachricht enthaltenen ersetzt."
     },
     "useConstraint": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
-    "addConstraint": "Abfrageeinschränkungen hinzufügen",
     "passThrough": "Die Nachricht durchreichen, wenn eine Nachricht ankommt?"
   }
 }

--- a/build/nodes/locales/de/firebase-in.json
+++ b/build/nodes/locales/de/firebase-in.json
@@ -4,8 +4,10 @@
       "database": "Datenbank",
       "listener": "Listener",
       "sortData": "Daten sortieren?",
+      "constraint": "Abfrageeinschränkungen",
       "path": "Pfad",
       "output": "Ausgabe",
+      "passThrough": "Durchreichen",
       "name": "Name"
     },
     "listenerType": {
@@ -16,30 +18,14 @@
       "child_moved": "Kind verschoben",
       "child_removed": "Kind gelöscht"
     },
-    "constraint": {
-      "orderByChild": "Nach Kindern sortieren",
-      "orderByKey": "Nach Schlüssel sortieren",
-      "orderByPriority": "Nach Priorität sortieren",
-      "orderByValue": "Nach Wert sortieren",
-      "limitToFirst": "Zum Anfang begrenzen",
-      "limitToLast": "Zum Ende begrenzen",
-      "endAt": "Ende bei",
-      "endBefore": "Ende vor",
-      "equalTo": "gleich zu",
-      "startAfter": "Starte nach",
-      "startAt": "Starte bei"
-    },
     "outputType": {
       "auto": "Automatisch erkennen",
       "string": "eine Zeichenkette"
     },
     "placeholder": {
-      "name": "Name",
-      "value": "Wert",
-      "child": "Kind Schlüssel"
+      "name": "Name"
     },
     "useConstraint": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
-    "addConstraint": "Abfrageeinschränkungen hinzufügen",
     "passThrough": "Die Nachricht durchreichen, wenn eine Nachricht ankommt?"
   }
 }

--- a/build/nodes/locales/de/load-config.json
+++ b/build/nodes/locales/de/load-config.json
@@ -1,0 +1,23 @@
+{
+  "query-constraints": {
+    "constraint": {
+      "orderByChild": "Nach Kindern sortieren",
+      "orderByKey": "Nach Schlüssel sortieren",
+      "orderByPriority": "Nach Priorität sortieren",
+      "orderByValue": "Nach Wert sortieren",
+      "limitToFirst": "Zum Anfang begrenzen",
+      "limitToLast": "Zum Ende begrenzen",
+      "endAt": "Ende bei",
+      "endBefore": "Ende vor",
+      "equalTo": "gleich zu",
+      "startAfter": "Starte nach",
+      "startAt": "Starte bei"
+    },
+    "placeholder": {
+      "name": "Name",
+      "value": "Wert",
+      "child": "Kind Schlüssel"
+    },
+    "addConstraint": "Abfrageeinschränkungen hinzufügen"
+  }
+}

--- a/build/nodes/locales/en-US/firebase-get.json
+++ b/build/nodes/locales/en-US/firebase-get.json
@@ -3,31 +3,18 @@
     "label": {
       "database": "Database",
       "sortData": "Sort Data?",
+      "constraint": "Constraint",
       "path": "Path",
       "output": "Output",
+      "passThrough": "Pass Through",
       "name": "Name"
-    },
-    "constraint": {
-      "orderByChild": "Order by Child",
-      "orderByKey": "Order by Key",
-      "orderByPriority": "Order by Priority",
-      "orderByValue": "Order by Value",
-      "limitToFirst": "Limit to First",
-      "limitToLast": "Limit to Last",
-      "endAt": "End At",
-      "endBefore": "End Before",
-      "equalTo": "Equal To",
-      "startAfter": "Start After",
-      "startAt": "Start At"
     },
     "outputType": {
       "auto": "auto-detect",
       "string": "a String"
     },
     "placeholder": {
-      "name": "Name",
-      "value": "Value",
-      "child": "Child Key"
+      "name": "Name"
     },
     "tips": {
       "tips": "<strong>Tips</strong>:",
@@ -35,7 +22,6 @@
       "tip1": "If <code>msg.method</code> is set, Query Constraints defined in the node will be replaced by those contained in the message."
     },
     "useConstraint": "Use Query Constraint to sort and order your data.",
-    "addConstraint": "Add Query Constraint Set",
     "passThrough": "If a message arrives, pass through the message?"
   }
 }

--- a/build/nodes/locales/en-US/firebase-in.json
+++ b/build/nodes/locales/en-US/firebase-in.json
@@ -4,8 +4,10 @@
       "database": "Database",
       "listener": "Listener",
       "sortData": "Sort Data?",
+      "constraint": "Constraint",
       "path": "Path",
       "output": "Output",
+      "passThrough": "Pass Through",
       "name": "Name"
     },
     "listenerType": {
@@ -16,30 +18,14 @@
       "child_moved": "Child Moved",
       "child_removed": "Child Removed"
     },
-    "constraint": {
-      "orderByChild": "Order by Child",
-      "orderByKey": "Order by Key",
-      "orderByPriority": "Order by Priority",
-      "orderByValue": "Order by Value",
-      "limitToFirst": "Limit to First",
-      "limitToLast": "Limit to Last",
-      "endAt": "End At",
-      "endBefore": "End Before",
-      "equalTo": "Equal To",
-      "startAfter": "Start After",
-      "startAt": "Start At"
-    },
     "outputType": {
       "auto": "auto-detect",
       "string": "a String"
     },
     "placeholder": {
-      "name": "Name",
-      "value": "Value",
-      "child": "Child Key"
+      "name": "Name"
     },
     "useConstraint": "Use Query Constraint to sort and order your data.",
-    "addConstraint": "Add Query Constraint Set",
     "passThrough": "If a message arrives, pass through the message?"
   }
 }

--- a/build/nodes/locales/en-US/load-config.json
+++ b/build/nodes/locales/en-US/load-config.json
@@ -1,0 +1,23 @@
+{
+  "query-constraints": {
+    "constraint": {
+      "orderByChild": "Order by Child",
+      "orderByKey": "Order by Key",
+      "orderByPriority": "Order by Priority",
+      "orderByValue": "Order by Value",
+      "limitToFirst": "Limit to First",
+      "limitToLast": "Limit to Last",
+      "endAt": "End At",
+      "endBefore": "End Before",
+      "equalTo": "Equal To",
+      "startAfter": "Start After",
+      "startAt": "Start At"
+    },
+    "placeholder": {
+      "name": "Name",
+      "value": "Value",
+      "child": "Child Key"
+    },
+    "addConstraint": "Add Query Constraint Set"
+  }
+}

--- a/build/nodes/locales/fr/firebase-get.json
+++ b/build/nodes/locales/fr/firebase-get.json
@@ -3,31 +3,18 @@
     "label": {
       "database": "Database",
       "sortData": "Trier ?",
+      "constraint": "Contraintes",
       "path": "Chemin",
       "output": "Sortie",
+      "passThrough": "Transmettre ?",
       "name": "Nom"
-    },
-    "constraint": {
-      "orderByChild": "Trier par enfant",
-      "orderByKey": "Trier par clé",
-      "orderByPriority": "Trier par priorité",
-      "orderByValue": "Trier par valeur",
-      "limitToFirst": "Limiter aux premiers",
-      "limitToLast": "Limiter aux derniers",
-      "endAt": "Terminer à",
-      "endBefore": "Terminer avant",
-      "equalTo": "Égal à",
-      "startAfter": "Commencer après",
-      "startAt": "Commencer à"
     },
     "outputType": {
       "auto": "détection automatique",
       "string": "une chaîne de caractères"
     },
     "placeholder": {
-      "name": "Nom",
-      "value": "Valeur",
-      "child": "Clé de l'enfant"
+      "name": "Nom"
     },
     "tips": {
       "tips": "<strong>Astuces</strong> :",
@@ -35,7 +22,6 @@
       "tip1": "Si <code>msg.method</code> est défini, les contraintes de la requête définies dans le noeuud seront remplacées par celles contenues dans le message."
     },
     "useConstraint": "Souhaitez-vous trier et ordonner vos données ?",
-    "addConstraint": "Ajouter une contrainte de requête",
     "passThrough": "Si un message arrive, transmettre le message ?"
   }
 }

--- a/build/nodes/locales/fr/firebase-in.json
+++ b/build/nodes/locales/fr/firebase-in.json
@@ -4,8 +4,10 @@
       "database": "Database",
       "listener": "Écouteur",
       "sortData": "Trier ?",
+      "constraint": "Contraintes",
       "path": "Chemin",
       "output": "Sortie",
+      "passThrough": "Transmettre ?",
       "name": "Nom"
     },
     "listenerType": {
@@ -16,30 +18,14 @@
       "child_moved": "Enfant déplacé",
       "child_removed": "Enfant supprimé"
     },
-    "constraint": {
-      "orderByChild": "Trier par enfant",
-      "orderByKey": "Trier par clé",
-      "orderByPriority": "Trier par priorité",
-      "orderByValue": "Trier par valeur",
-      "limitToFirst": "Limiter aux premiers",
-      "limitToLast": "Limiter aux derniers",
-      "endAt": "Terminer à",
-      "endBefore": "Terminer avant",
-      "equalTo": "Égal à",
-      "startAfter": "Commencer après",
-      "startAt": "Commencer à"
-    },
     "outputType": {
       "auto": "détection automatique",
       "string": "une chaîne de caractères"
     },
     "placeholder": {
-      "name": "Nom",
-      "value": "Valeur",
-      "child": "Clé de l'enfant"
+      "name": "Nom"
     },
     "useConstraint": "Souhaitez-vous trier et ordonner vos données ?",
-    "addConstraint": "Ajouter une contrainte de requête",
     "passThrough": "Si un message arrive, transmettre le message ?"
   }
 }

--- a/build/nodes/locales/fr/load-config.json
+++ b/build/nodes/locales/fr/load-config.json
@@ -1,0 +1,23 @@
+{
+  "query-constraints": {
+    "constraint": {
+      "orderByChild": "Trier par enfant",
+      "orderByKey": "Trier par clé",
+      "orderByPriority": "Trier par priorité",
+      "orderByValue": "Trier par valeur",
+      "limitToFirst": "Limiter aux premiers",
+      "limitToLast": "Limiter aux derniers",
+      "endAt": "Terminer à",
+      "endBefore": "Terminer avant",
+      "equalTo": "Égal à",
+      "startAfter": "Commencer après",
+      "startAt": "Commencer à"
+    },
+    "placeholder": {
+      "name": "Nom",
+      "value": "Valeur",
+      "child": "Clé de l'enfant"
+    },
+    "addConstraint": "Ajouter une contrainte de requête"
+  }
+}

--- a/build/nodes/on-disconnect.html
+++ b/build/nodes/on-disconnect.html
@@ -15,9 +15,12 @@
 -->
 
 <script type="text/javascript">
+	"use strict";
+
 	(function () {
-		let sendMsgEventOption = ["onConnected", "onDisconnect"];
-		let translationInitialized = false;
+		const i18n = (key) => FirebaseUI._(key, "on-disconnect");
+		const sendMsgEventOption = ["onConnected", "onDisconnect"].map((fieldName) => ({ value: fieldName, label: i18n(`sendMsgEvent.${fieldName}`) }));
+		const { typedPathField, validators } = FirebaseUI;
 
 		RED.nodes.registerType("on-disconnect", {
 			align: "left",
@@ -28,10 +31,10 @@
 				database: { value: "", type: "firebase-config" },
 				inputs: { value: 1 },
 				outputs: { value: 0 },
-				path: { value: "topic" },
-				pathType: { value: "msg", validate: RED.validators.regex(/^(msg|str)$/) },
-				sendMsgEvent: { value: "" },
-				queryType: { value: "msg", validate: RED.validators.regex(/^(msg|none|cancel|set|update|remove|setWithPriority)$/) },
+				path: { value: "topic", label: i18n("label.path"), validate: validators.typedInput("pathType") },
+				pathType: { value: "msg", label: i18n("label.path"), validate: validators.pathType() },
+				sendMsgEvent: { value: "", label: i18n("label.sendMsgEvent"), validate: validators.sendMsgEvent() },
+				queryType: { value: "msg", label: i18n("label.query"), validate: validators.onDisconnectQueryType() },
 			},
 			inputs: 1,
 			outputs: 0,
@@ -51,20 +54,10 @@
 				return this.name ? "node_label_italic" : "";
 			},
 			oneditprepare: function () {
+				const pathField = typedPathField.create(false);
 				const queryType = $("#node-input-queryType");
-				const node = this;
 
-				$("#node-input-path").typedInput({
-					typeField: $("#node-input-pathType"),
-					types: ["msg", { value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: isPathValid }],
-				});
-
-				if (!translationInitialized) {
-					translationInitialized = true;
-					sendMsgEventOption = sendMsgEventOption.map((fieldName) => ({ value: fieldName, label: node._(`on-disconnect.sendMsgEvent.${fieldName}`) }));
-				}
-
-				$("#node-input-sendMsgEvent").typedInput({ type: "event", types: [{ value: "event", multiple: true, options: sendMsgEventOption, validate: RED.validators.regex(/^(onConnected,)?(|onConnected|onDisconnect)$/) }] });
+				$("#node-input-sendMsgEvent").typedInput({ type: "event", types: [{ value: "event", multiple: true, options: sendMsgEventOption, validate: validators.sendMsgEvent() }] });
 
 				queryType.on("change", () => queryType.val() === "none" ? $(".form-row-path").hide() : $(".form-row-path").show());
 			},
@@ -76,12 +69,6 @@
 				$("#node-input-outputs").val(array.length);
 			}
 		});
-
-		function isPathValid(x) {
-			if (!x || typeof x !== "string") return false;
-			if (x.match(/^\s|[.#$\[\]]/g)) return false;
-			return true;
-		}
 	})();
 </script>
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gogovega/node-red-contrib-firebase-realtime-database",
   "version": "0.6.0-alpha.1",
   "description": "Node-RED nodes to communicate with Google Firebase Realtime Databases",
-  "main": "build/nodes/database.js",
+  "main": "build/nodes/load-config.js",
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf build/lib build/**/*.js",
@@ -41,11 +41,11 @@
   "homepage": "https://github.com/GogoVega/node-red-contrib-firebase-realtime-database#readme",
   "node-red": {
     "nodes": {
+      "load-config": "build/nodes/load-config.js",
       "firebase-config": "../firebase-config-node/build/nodes/firebase-config.js",
       "firebase-in": "build/nodes/firebase-in.js",
       "firebase-get": "build/nodes/firebase-get.js",
       "firebase-out": "build/nodes/firebase-out.js",
-      "load-config": "build/nodes/load-config.js",
       "on-disconnect": "build/nodes/on-disconnect.js"
     },
     "version": ">=1.3.7"
@@ -69,8 +69,9 @@
   },
   "files": [
     "build/",
-    "CHANGELOG.md",
     "examples/",
+    "resources/",
+    "CHANGELOG.md",
     "LICENSE",
     "README.md",
     "SECURITY.md",

--- a/resources/common.js
+++ b/resources/common.js
@@ -1,0 +1,123 @@
+"use strict";
+
+const FirebaseUI = (function () {
+	const validators = {
+		boolean: function () {
+			return function (value, opt) {
+				// TODO: checkbox returns "on"
+				if (typeof value === "boolean" || value === "true" || value === "false") return true;
+				return false;
+			}
+		},
+		child: function (blankAllowed = false) {
+			const regex = blankAllowed ? /[\s.#$\[\]]/ : /^$|[\s.#$\[\]]/;
+			return function (value, opt) {
+				if (typeof value === "string" && !regex.test(value)) return true;
+				return false;
+			}
+		},
+		listenerType: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(none|value|child_added|child_changed|child_moved|child_removed)$/.test(value)) return true;
+				return false;
+			}
+		},
+		onDisconnectQueryType: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(msg|none|cancel|set|update|remove|setWithPriority)$/.test(value)) return true;
+				return false;
+			}
+		},
+		outputType: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(auto|string)$/.test(value)) return true;
+				return false;
+			}
+		},
+		path: function (blankAllowed = false) {
+			const regex = blankAllowed ? /[\s.#$\[\]]/ : /^$|[\s.#$\[\]]/;
+			return function (value, opt) {
+				if (typeof value === "string" && !regex.test(value)) return true;
+				return false;
+			}
+		},
+		pathType: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(msg|str)$/.test(value)) return true;
+				return false;
+			}
+		},
+		priority: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^[1-9][0-9]*$/.test(value)) return true;
+				return false;
+			}
+		},
+		queryType: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(none|set|push|update|remove|setPriority|setWithPriority)$/.test(value)) return true;
+				return false;
+			}
+		},
+		sendMsgEvent: function () {
+			return function (value, opt) {
+				if (typeof value === "string" && /^(onConnected,)?(|onConnected|onDisconnect)$/.test(value)) return true;
+				return false;
+			}
+		},
+		typedInput: function (typeName, opts = {}) {
+			return (value, opt) => {
+				const type = $(`#node-input-${typeName}`).val();
+				const { blankAllowed } = opts;
+
+				if (type === "str" && typeName === "pathType") {
+					const validatePath = this.path(blankAllowed);
+					return validatePath(value, opt);
+				}
+
+				const validateTypedProperty = RED.validators.typedInput(typeName);
+				return validateTypedProperty(value, opt);
+			}
+		},
+	};
+
+	class TypedPathInput {
+		constructor(blankAllowed) {
+			this.staticFieldOptions = [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: validators.path(blankAllowed) }];
+			this.dynamicFieldOptions = [...this.staticFieldOptions, "msg"];
+			this.pathField = $("#node-input-path");
+			this.#build();
+		}
+
+		#build() {
+			this.pathField.typedInput({
+				typeField: "#node-input-pathType",
+				types: this.dynamicFieldOptions,
+			});
+		}
+
+		updateTypesToStaticOrDynamic(dynamic) {
+			const types = dynamic ? this.dynamicFieldOptions : this.staticFieldOptions;
+			this.pathField.typedInput("types", types);
+		}
+	}
+
+	function i18n(key, tplStrs) {
+		return RED._(`@gogovega/node-red-contrib-firebase-realtime-database/load-config:validator.${key}`, tplStrs);
+	}
+
+	function i18nFullOptions(key, dict, group = "", tplStrs) {
+		if (typeof group === "object" && !tplStrs) {
+			tplStrs = group;
+			group = "";
+		}
+
+		return RED._(`@gogovega/node-red-contrib-firebase-realtime-database/${dict}:${group || dict}.${key}`, tplStrs);
+	}
+
+	return {
+		_: i18nFullOptions,
+		typedPathField: { create: (blankAllowed) => new TypedPathInput(blankAllowed) },
+		validators: validators,
+	};
+})();

--- a/resources/constraints-container.js
+++ b/resources/constraints-container.js
@@ -1,0 +1,284 @@
+"use strict";
+
+const FirebaseQueryConstraintsContainer = (function () {
+	const queryConstraintTypes = new Array("endAt", "endBefore", "equalTo", "limitToFirst", "limitToLast", "orderByChild", "orderByKey", "orderByPriority", "orderByValue", "startAfter", "startAt");
+	const queryConstraintFieldOptions = queryConstraintTypes.map((fieldName) => (
+		{ value: fieldName, label: i18n(`constraint.${fieldName}`) }
+	));
+
+	class EditableQueryConstraintsList {
+		// TODO: constraint to plural
+		constructor() {
+			this.containerId = "#node-input-constraints-container";
+			this.containerClass = ".node-input-constraints-container-row";
+			this.useConstraintsId = "#node-input-useConstraint";
+			this.node = {};
+		}
+
+		#buildContainer() {
+			this.container?.css({ "min-height": "150px", "min-width": "300px" }).editableList({
+				addButton: i18n("addConstraint"),
+				addItem: addItem,
+				removable: true,
+				sortable: true,
+			});
+
+			this.useConstraints?.on("change", () => this.#constraintsHandler());
+		}
+
+		#constraintsHandler() {
+			if (this.useConstraints?.prop("checked") === true) {
+				const constraints = Object.entries(this.node.constraint || {});
+
+				if (!constraints.length) constraints.push(["limitToLast", 5]);
+
+				constraints.forEach((item) => this.container?.editableList("addItem", item));
+				this.containerRow?.show();
+			} else {
+				this.containerRow?.hide();
+				this.container?.editableList("empty");
+			}
+
+			RED.tray.resize();
+		}
+
+		build(node) {
+			this.container = $(this.containerId);
+			this.containerRow = $(this.containerClass);
+			this.useConstraints = $(this.useConstraintsId);
+			this.node = node;
+			this.#buildContainer();
+		}
+
+		reSize(size) {
+			let height = size.height;
+			const rows = $(`#dialog-form>div:not(${this.containerClass})`);
+			const editorRow = $(`#dialog-form>div${this.containerClass}`);
+
+			for (let i = 0; i < rows.length; i++) {
+				height -= $(rows[i]).outerHeight(true) || 0;
+			}
+
+			height -= (parseInt(editorRow.css("marginTop")) + parseInt(editorRow.css("marginBottom")));
+			height += 16;
+			this.container?.editableList("height", height);
+		}
+
+		saveItems() {
+			const node = this.node;
+			this.container?.editableList("items").sort(compareItemsList);
+
+			// TODO: constraint to plural
+			this.node.constraint = {};
+
+			this.container?.each(function () {
+				const constraintType = $(this).find("#node-input-constraint-type").typedInput("value");
+				const value = $(this).find("#node-input-constraint-value").val();
+				const child = $(this).find("#node-input-constraint-child").val() || undefined;
+				const type = $(this).find("#node-input-constraint-value").typedInput("type");
+
+				switch (constraintType) {
+					case "endAt":
+					case "endBefore":
+					case "equalTo":
+					case "startAfter":
+					case "startAt": {
+						let valueParsed =
+							// TODO: Use server timestamp
+							type === "date" ? Date.now() :
+								type === "null" ? null :
+									type === "num" ? Number(value) :
+										type === "bool" ? (value === "true" ? true : false) :
+											value;
+
+						if (type === "num" && Number.isNaN(valueParsed)) {
+							RED.notify("Query Constraints: Setted value is not a number!", "error");
+							valueParsed = value;
+						}
+
+						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
+						break;
+					}
+					case "limitToFirst":
+					case "limitToLast": {
+						let valueParsed = Number(value || NaN);
+						if (!Number.isInteger(valueParsed) || valueParsed <= 0) {
+							RED.notify("Query Constraints: Setted value is not an integrer > 0!", "error");
+							valueParsed = value;
+						}
+
+						node.constraint[constraintType] = valueParsed;
+						break;
+					}
+					case "orderByChild":
+						if (!isChildValid(child, constraintType)) RED.notify("Query Constraints: Setted value is not a valid child!", "error");
+						// TODO: check null => invalid child
+						node.constraint[constraintType] = child;
+						break;
+					case "orderByKey":
+					case "orderByPriority":
+					case "orderByValue":
+						node.constraint[constraintType] = null;
+						break;
+				}
+			});
+		}
+	}
+
+	function addItem(container, index, data) {
+		const inputRows = $("<div></div>", { style: "flex-grow: 1" }).appendTo(container);
+		const row = $("<div/>", { style: "width: 45%; vertical-align: top; display: inline-block;" }).appendTo(inputRows);
+		const row2 = $("<div/>", { style: "width: calc(54% - 5px); margin-left: 5px; vertical-align: top; display: inline-block;" }).appendTo(inputRows);
+		const row3 = $("<div/>", { class: "constraints-container-row-value" }).appendTo(row2);
+		const constraintType = $("<input/>", { type: "text", id: "node-input-constraint-type", style: "width: 100%; text-align: center;" }).appendTo(row);
+		const valueField = $("<input/>", { type: "text", id: "node-input-constraint-value", style: "width: 100%;", placeholder: i18n("placeholder.value") }).appendTo(row3);
+		const childField = $("<input/>", { type: "text", id: "node-input-constraint-child", style: "width: 100%;", placeholder: i18n("placeholder.child") }).appendTo(row2);
+		$("<input/>", { type: "hidden", id: "node-input-constraint-valueType" }).appendTo(row3);
+
+		container.css({
+			overflow: "auto",
+			whiteSpace: "normal",
+			display: "flex",
+			"align-items": "center",
+		});
+
+		valueField.typedInput({ default: "num", typeField: "#node-input-constraint-valueType", types: ["num"] });
+		childField
+			.typedInput({ default: "str", types: [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: (child) => isChildValid(child, constraintType.val()) }] })
+			.typedInput("hide");
+
+		constraintType
+			.on("change", (_event, _type, value) => updateTypeOfTypedInput(valueField, row3, childField, value))
+			.typedInput({ types: [{ options: queryConstraintFieldOptions }] })
+			.typedInput("value", "orderByValue");
+
+		// if known value (previously defined)
+		if (Array.isArray(data)) {
+			const [key, value] = data;
+
+			constraintType.typedInput("value", key);
+
+			if (value && typeof value === "object") {
+				valueField.typedInput("value", value.value?.toString() ?? "");
+				valueField.typedInput("type", value.type ?? "str");
+				childField.typedInput("value", value.key ?? "");
+			} else {
+				if (key === "orderByChild") {
+					valueField.typedInput("value", "");
+					childField.typedInput("value", value ?? "");
+				} else {
+					valueField.typedInput("value", value ?? "");
+					childField.typedInput("value", "");
+				}
+			}
+
+			data = {};
+			$(container).data("data", data);
+		}
+
+		data.index = index;
+	}
+
+	function compareItemsList(a, b) {
+		return a.index - b.index;
+	}
+
+	function i18n(key) {
+		return FirebaseUI._(key, "load-config", "query-constraints");
+	}
+
+	function isChildValid(child, constraintType) {
+		const empty = constraintType !== "orderByChild";
+		const regex = empty ? /[\s.#$\[\]]/ : /^$|[\s.#$\[\]]/;
+		if (typeof child === "string" && !regex.test(child)) return true;
+		return false;
+	}
+
+	function isConstraintsValid() {
+		return function (constraints, opt) {
+			if (typeof constraints !== "object") return false;
+
+			for (const [k, v] of Object.entries(constraints)) {
+				switch (k) {
+					case "endAt":
+					case "endBefore":
+					case "equalTo":
+					case "startAfter":
+					case "startAt": {
+						if (typeof v !== "object" || v === null) return false;
+
+						const valueValidation = FirebaseUI.validators.typedInput("constraint-valueType")(v.value, opt);
+						if (valueValidation !== true) return valueValidation;
+
+						const keyValidation = FirebaseUI.validators.child(true)(v.key, opt);
+						if (keyValidation !== true) return keyValidation;
+
+						if ((v.type === "date" || v.type === "num") && (typeof v.value !== "number" || Number.isNaN(v.value))) return false;
+						if (v.type === "bool" && typeof v.value !== "boolean") return false;
+						if (v.type === "null" && v.value !== null) return false;
+						if (v.type === "str" && typeof v.value !== "string") return false;
+						break;
+					}
+					case "limitToFirst":
+					case "limitToLast": {
+						const validation = FirebaseUI.validators.priority()(v, opt);
+						if (validation !== true) return validation;
+						break;
+					}
+					case "orderByChild": {
+						const validation = FirebaseUI.validators.child()(v, opt);
+						if (validation !== true) return validation;
+						break;
+					}
+					case "orderByKey":
+					case "orderByPriority":
+					case "orderByValue":
+						if (v !== null) return false;
+						break;
+					default:
+						return false;
+				}
+			}
+
+			return true;
+		}
+	}
+
+	function updateTypeOfTypedInput(value, valueContainer, child, key) {
+		// Initial state
+		value.typedInput("show");
+		valueContainer.css("padding-bottom", "0px");
+		child.typedInput("hide");
+		child.typedInput("value", "");
+
+		switch (key) {
+			case "endAt":
+			case "endBefore":
+			case "equalTo":
+			case "startAfter":
+			case "startAt":
+				value.typedInput("types", ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }]);
+				valueContainer.css("padding-bottom", "5px");
+				child.typedInput("show");
+				break;
+			case "limitToFirst":
+			case "limitToLast":
+				value.typedInput("types", ["num"]);
+				break;
+			case "orderByChild":
+				value.typedInput("hide");
+				child.typedInput("show");
+				break;
+			case "orderByKey":
+			case "orderByPriority":
+			case "orderByValue":
+				value.typedInput("hide");
+				break;
+		}
+	}
+
+	return {
+		editableConstraintsList: { create: () => new EditableQueryConstraintsList() },
+		validators: { isConstraintsValid },
+	};
+})();


### PR DESCRIPTION
Moved all common methods to resources to remove duplicates.

These methods have been separated into two resources:

- Common
- Query Constraints

The validation functions have become stricter in order to ask the user to redeploy!

I would try to add these changes to the Migration Wizard so that the user doesn't have to do anything anymore