### PR TITLE
(QueryConstraints) `constraint` and `msg.method` are deprecated

### DIFF
--- a/build/nodes/firebase-get.html
+++ b/build/nodes/firebase-get.html
@@ -29,13 +29,15 @@
 			color: "#e2a12b",
 			defaults: {
 				name: { value: "" },
-				constraint: { value: {}, label: i18n("label.constraint"), validate: isConstraintsValid() },
+				constraint: {},	// Legacy Config
+				constraints: { value: {}, label: i18n("label.constraints"), validate: isConstraintsValid() },
 				database: { value: "", type: "firebase-config" },
 				outputType: { value: "auto", label: i18n("label.output"), validate: validators.outputType() },
 				passThrough: { value: false, label: i18n("label.passThrough") },
 				path: { value: "topic", label: i18n("label.path"), validate: validators.typedInput("pathType", { blankAllowed: true }) },
 				pathType: { value: "msg", label: i18n("label.path"), validate: validators.pathType() },
-				useConstraint: { value: false, label: i18n("label.sortData") },
+				useConstraints: { value: false, label: i18n("label.sortData") },
+				useConstraint: {},	// Legacy Config
 			},
 			inputs: 1,
 			outputs: 1,
@@ -66,9 +68,9 @@
 	</div>
 
 	<div class="form-row">
-		<label for="node-input-useConstraint"><i class="fa fa-sort"></i> <span data-i18n="firebase-get.label.sortData"></span></label>
-		<input type="checkbox" id="node-input-useConstraint" style="display:inline-block; width:15px; vertical-align:baseline;" />
-		<span data-i18n="firebase-get.useConstraint"></span>
+		<label for="node-input-useConstraints"><i class="fa fa-sort"></i> <span data-i18n="firebase-get.label.sortData"></span></label>
+		<input type="checkbox" id="node-input-useConstraints" style="display:inline-block; width:15px; vertical-align:baseline;" />
+		<span data-i18n="firebase-get.useConstraints"></span>
 	</div>
 
 	<div class="form-row node-input-constraints-container-row">

--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -29,7 +29,8 @@
 			color: "#e2a12b",
 			defaults: {
 				name: { value: "" },
-				constraint: { value: {}, label: i18n("label.constraint"), validate: isConstraintsValid() },
+				constraint: {},	// Legacy Config
+				constraints: { value: {}, label: i18n("label.constraints"), validate: isConstraintsValid() },
 				database: { value: "", type: "firebase-config" },
 				inputs: { value: 0 },
 				listenerType: { value: "value", label: i18n("label.listener"), validate: validators.listenerType() },
@@ -37,7 +38,8 @@
 				passThrough: { value: false, label: i18n("label.passThrough") },
 				path: { value: "test/stream", label: i18n("label.path"), validate: validators.typedInput("pathType", { blankAllowed: true }) },
 				pathType: { value: "str", label: i18n("label.path"), validate: validators.pathType() },
-				useConstraint: { value: false, label: i18n("label.sortData") },
+				useConstraints: { value: false, label: i18n("label.sortData") },
+				useConstraint: {},	// Legacy Config
 			},
 			inputs: 0,
 			outputs: 1,
@@ -88,9 +90,9 @@
 	</div>
 
 	<div class="form-row">
-		<label for="node-input-useConstraint"><i class="fa fa-sort"></i> <span data-i18n="firebase-in.label.sortData"></span></label>
-		<input type="checkbox" id="node-input-useConstraint" style="display:inline-block; width:15px; vertical-align:baseline;" />
-		<span data-i18n="firebase-in.useConstraint"></span>
+		<label for="node-input-useConstraints"><i class="fa fa-sort"></i> <span data-i18n="firebase-in.label.sortData"></span></label>
+		<input type="checkbox" id="node-input-useConstraints" style="display:inline-block; width:15px; vertical-align:baseline;" />
+		<span data-i18n="firebase-in.useConstraints"></span>
 	</div>
 
 	<div class="form-row node-input-constraints-container-row">

--- a/build/nodes/locales/de/firebase-get.html
+++ b/build/nodes/locales/de/firebase-get.html
@@ -27,7 +27,7 @@
 	</p>
 	<h3>Eingaben</h3>
 	<dl class="message-properties">
-		<dt class="optional">method<span class="property-type">Objekt</span></dt>
+		<dt class="optional">constraints<span class="property-type">Objekt</span></dt>
 		<dd>ein Objekt, das die Einschränkung(en) enthält, die auf die Abfrage angewendet werden sollen.</dd>
 		<dt class="optional">topic<span class="property-type">Zeichenkette</span></dt>
 		<dd>der Pfad der abzurufenden Daten. Standardmäßig 'topic'.</dd>
@@ -61,7 +61,7 @@
 	</p>
 	<p>
 		Sie können Einschränkungen für die Abfrage definieren, um Ihre Daten zu sortieren und zu ordnen. Sie können eine
-		oder mehrere der folgenden Einschränkungen in der Eigenschaft <code>msg.method</code> oder direkt im Node
+		oder mehrere der folgenden Einschränkungen in der Eigenschaft <code>msg.constraints</code> oder direkt im Node
 		definieren:
 	</p>
 	<ul>
@@ -77,7 +77,7 @@
 		<li><code>startAfter</code><span class="property-type">Objekt</span></li>
 		<li><code>startAt</code><span class="property-type">Objekt</span></li>
 	</ul>
-	<p><code>msg.method</code> schaut folgendermaßen aus:</p>
+	<p><code>msg.constraints</code> schaut folgendermaßen aus:</p>
 	<pre>
 {
   "orderByChild": "name",

--- a/build/nodes/locales/de/firebase-get.json
+++ b/build/nodes/locales/de/firebase-get.json
@@ -3,7 +3,7 @@
     "label": {
       "database": "Datenbank",
       "sortData": "Daten sortieren?",
-      "constraint": "Abfrageeinschränkungen",
+      "constraints": "Abfrageeinschränkungen",
       "path": "Pfad",
       "output": "Ausgabe",
       "passThrough": "Durchreichen",
@@ -21,7 +21,7 @@
       "tip0": "Sie können Einschränkungen für die Abfrage verwenden in dem sie die <code>msg.method</code> Eigenschaft setzen.",
       "tip1": "Wenn <code>msg.method</code> gesetzt ist, werden die im Knoten definierten Abfrageeinschränkungen durch die Nachricht enthaltenen ersetzt."
     },
-    "useConstraint": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
+    "useConstraints": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
     "passThrough": "Die Nachricht durchreichen, wenn eine Nachricht ankommt?"
   }
 }

--- a/build/nodes/locales/de/firebase-in.html
+++ b/build/nodes/locales/de/firebase-in.html
@@ -18,6 +18,15 @@
 	<p>
 		Stellt eine Verbindung zu einer Firebase Realtime Database her und abonniert die Daten unter dem angegebenen Pfad.
 	</p>
+	<h3>Eingaben</h3>
+	<dl class="message-properties">
+		<dt>listener<span class="property-type">Zeichenkette</span></dt>
+		<dd>welche Art von Veränderung Sie verwenden möchten.</dd>
+		<dt class="optional">constraints<span class="property-type">Objekt</span></dt>
+		<dd>ein Objekt, das die Einschränkung(en) enthält, die auf die Abfrage angewendet werden sollen.</dd>
+		<dt class="optional">topic<span class="property-type">Zeichenkette</span></dt>
+		<dd>der Pfad der abzurufenden Daten. Standardmäßig 'topic'.</dd>
+	</dl>
 	<h3>Ausgabe</h3>
 	<dl class="message-properties">
 		<dt>payload<span class="property-type">Zeichenkette | Wahrheitswert | Zahl | Liste | Objekt | Null</span></dt>
@@ -39,6 +48,7 @@
 	</p>
 	<p>Der <strong>Listener</strong> ermöglicht es Ihnen zu wählen, welche Art von Veränderung Sie verwenden möchten:</p>
 	<ul>
+		<li><code>- verwende msg.listener -</code></li>
 		<li><code>Wert</code></li>
 		<li><code>Kind hinzugefügt</code></li>
 		<li><code>Kind aktualisiert</code></li>
@@ -46,8 +56,9 @@
 		<li><code>Kind gelöscht</code></li>
 	</ul>
 	<p>
-		Der <strong>Pfad</strong> bestimmt, von wo die Daten gelesen werden. Er kann leer sein, in diesem Fall kommen die
-		Daten von der Wurzel der Datenbank kommen.
+		Der <strong>Pfad</strong> bestimmt, von wo die Daten gelesen werden. Er kann im Node oder dynamisch mit der
+		Eigenschaft <code>msg.topic</code> definiert werden. Er kann leer sein, in diesem Fall kommen die gesendeten Daten
+		aus dem Stamm der Datenbank.
 	</p>
 	<p>
 		<strong>Ausgabe</strong> kann auf <strong>Automatisch erkennen</strong> gesetzt werden, um ein Objekt zu senden, das
@@ -55,7 +66,7 @@
 	</p>
 	<p>
 		Sie können Einschränkungen für die Abfrage definieren, um Ihre Daten zu sortieren und zu ordnen. Sie können eine
-		oder mehrere der folgenden Einschränkungen in der Eigenschaft <code>msg.method</code> oder direkt im Node
+		oder mehrere der folgenden Einschränkungen in der Eigenschaft <code>msg.constraints</code> oder direkt im Node
 		definieren:
 	</p>
 	<ul>
@@ -71,7 +82,7 @@
 		<li><code>startAfter</code><span class="property-type">Objekt</span></li>
 		<li><code>startAt</code><span class="property-type">Objekt</span></li>
 	</ul>
-	<p><code>msg.method</code> schaut folgendermaßen aus:</p>
+	<p><code>msg.constraints</code> schaut folgendermaßen aus:</p>
 	<pre>
 {
   "orderByChild": "name",

--- a/build/nodes/locales/de/firebase-in.json
+++ b/build/nodes/locales/de/firebase-in.json
@@ -4,7 +4,7 @@
       "database": "Datenbank",
       "listener": "Listener",
       "sortData": "Daten sortieren?",
-      "constraint": "Abfrageeinschränkungen",
+      "constraints": "Abfrageeinschränkungen",
       "path": "Pfad",
       "output": "Ausgabe",
       "passThrough": "Durchreichen",
@@ -25,7 +25,7 @@
     "placeholder": {
       "name": "Name"
     },
-    "useConstraint": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
+    "useConstraints": "Verwende Abfrageeinschränkungen um ihre Daten zu sortieren.",
     "passThrough": "Die Nachricht durchreichen, wenn eine Nachricht ankommt?"
   }
 }

--- a/build/nodes/locales/en-US/firebase-get.html
+++ b/build/nodes/locales/en-US/firebase-get.html
@@ -27,7 +27,7 @@
 	</p>
 	<h3>Inputs</h3>
 	<dl class="message-properties">
-		<dt class="optional">method<span class="property-type">object</span></dt>
+		<dt class="optional">constraints<span class="property-type">object</span></dt>
 		<dd>an object containing the constraint(s) to apply to the query.</dd>
 		<dt class="optional">topic<span class="property-type">string</span></dt>
 		<dd>the path of the data to fetch. By default 'topic'.</dd>
@@ -56,7 +56,7 @@
 	</p>
 	<p>
 		You can define constraints for the query to sort and order your data. You can define one or more of the following
-		constraints in the <code>msg.method</code> property or directly in the node:
+		constraints in the <code>msg.constraints</code> property or directly in the node:
 	</p>
 	<ul>
 		<li><code>endAt</code><span class="property-type">object</span></li>
@@ -71,7 +71,7 @@
 		<li><code>startAfter</code><span class="property-type">object</span></li>
 		<li><code>startAt</code><span class="property-type">object</span></li>
 	</ul>
-	<p>The <code>msg.method</code> will look like this:</p>
+	<p>The <code>msg.constraints</code> will look like this:</p>
 	<pre>
 {
   "orderByChild": "name",

--- a/build/nodes/locales/en-US/firebase-get.json
+++ b/build/nodes/locales/en-US/firebase-get.json
@@ -3,7 +3,7 @@
     "label": {
       "database": "Database",
       "sortData": "Sort Data?",
-      "constraint": "Constraint",
+      "constraints": "Constraint",
       "path": "Path",
       "output": "Output",
       "passThrough": "Pass Through",
@@ -21,7 +21,7 @@
       "tip0": "You can use constraint(s) for the query by setting the <code>msg.method</code> property.",
       "tip1": "If <code>msg.method</code> is set, Query Constraints defined in the node will be replaced by those contained in the message."
     },
-    "useConstraint": "Use Query Constraint to sort and order your data.",
+    "useConstraints": "Use Query Constraints to sort and order your data.",
     "passThrough": "If a message arrives, pass through the message?"
   }
 }

--- a/build/nodes/locales/en-US/firebase-in.html
+++ b/build/nodes/locales/en-US/firebase-in.html
@@ -16,6 +16,15 @@
 
 <script type="text/html" data-help-name="firebase-in">
 	<p>Connects to a Firebase Realtime Database and subscribes to data at the specified path.</p>
+	<h3>Inputs</h3>
+	<dl class="message-properties">
+		<dt>listener<span class="property-type">string</span></dt>
+		<dd>what type of change you want to listen to.</dd>
+		<dt class="optional">constraints<span class="property-type">object</span></dt>
+		<dd>an object containing the constraint(s) to apply to the query.</dd>
+		<dt class="optional">topic<span class="property-type">string</span></dt>
+		<dd>the path of the data to fetch. By default 'topic'.</dd>
+	</dl>
 	<h3>Outputs</h3>
 	<dl class="message-properties">
 		<dt>payload<span class="property-type">string | boolean | number | array | object | null</span></dt>
@@ -31,6 +40,7 @@
 	<p>This node reads data from a path and will send a message whenever the data, including children, changes.</p>
 	<p>The <strong>Listener</strong> allows you to choose what type of change you want to listen to:</p>
 	<ul>
+		<li><code>- use msg.listener -</code></li>
 		<li><code>Value</code></li>
 		<li><code>Child Added</code></li>
 		<li><code>Child Changed</code></li>
@@ -38,8 +48,9 @@
 		<li><code>Child Removed</code></li>
 	</ul>
 	<p>
-		The <strong>Path</strong> determines where the data will be read from. It can be empty, in this case the data sent
-		comes from the root of the database.
+		The <strong>Path</strong> determines where the data will be read from. It can be defined in the node or dynamically
+		with the <code>msg.topic</code> property. It can be empty, in this case the data sent comes from the root of the
+		database.
 	</p>
 	<p>
 		<strong>Output</strong> can be set to <strong>auto-detect</strong> to send an object containing the data, or
@@ -47,7 +58,7 @@
 	</p>
 	<p>
 		You can define query constraint(s) to sort and order your data. You can define one or more of the following
-		constraints in the <code>msg.method</code> property or directly in the node:
+		constraints in the <code>msg.constraints</code> property or directly in the node:
 	</p>
 	<ul>
 		<li><code>endAt</code><span class="property-type">object</span></li>
@@ -62,7 +73,7 @@
 		<li><code>startAfter</code><span class="property-type">object</span></li>
 		<li><code>startAt</code><span class="property-type">object</span></li>
 	</ul>
-	<p>The <code>msg.method</code> will look like this:</p>
+	<p>The <code>msg.constraints</code> will look like this:</p>
 	<pre>
 {
   "orderByChild": "name",

--- a/build/nodes/locales/en-US/firebase-in.json
+++ b/build/nodes/locales/en-US/firebase-in.json
@@ -4,7 +4,7 @@
       "database": "Database",
       "listener": "Listener",
       "sortData": "Sort Data?",
-      "constraint": "Constraint",
+      "constraints": "Constraint",
       "path": "Path",
       "output": "Output",
       "passThrough": "Pass Through",
@@ -25,7 +25,7 @@
     "placeholder": {
       "name": "Name"
     },
-    "useConstraint": "Use Query Constraint to sort and order your data.",
+    "useConstraints": "Use Query Constraints to sort and order your data.",
     "passThrough": "If a message arrives, pass through the message?"
   }
 }

--- a/build/nodes/locales/fr/firebase-get.html
+++ b/build/nodes/locales/fr/firebase-get.html
@@ -27,7 +27,7 @@
 	</p>
 	<h3>Entrées</h3>
 	<dl class="message-properties">
-		<dt class="optional">method<span class="property-type">objet</span></dt>
+		<dt class="optional">constraints<span class="property-type">objet</span></dt>
 		<dd>un objet contenant la ou les contraintes à appliquer à la requête.</dd>
 		<dt class="optional">topic<span class="property-type">chaîne de caractères</span></dt>
 		<dd>le chemin des données à lire. Par défaut 'topic'.</dd>
@@ -59,7 +59,7 @@
 	</p>
 	<p>
 		Vous pouvez définir des contraintes pour la requête afin de trier et d'ordonner vos données. Vous pouvez définir une
-		ou plusieurs des contraintes suivantes dans la propriété <code>msg.method</code> ou directement dans le noeud :
+		ou plusieurs des contraintes suivantes dans la propriété <code>msg.constraints</code> ou directement dans le noeud :
 	</p>
 	<ul>
 		<li><code>endAt</code><span class="property-type">objet</span></li>
@@ -74,7 +74,7 @@
 		<li><code>startAfter</code><span class="property-type">objet</span></li>
 		<li><code>startAt</code><span class="property-type">objet</span></li>
 	</ul>
-	<p>Le <code>msg.method</code> ressemblera à ceci :</p>
+	<p>Le <code>msg.constraints</code> ressemblera à ceci :</p>
 	<pre>
 {
   "orderByChild": "nom",

--- a/build/nodes/locales/fr/firebase-get.json
+++ b/build/nodes/locales/fr/firebase-get.json
@@ -3,7 +3,7 @@
     "label": {
       "database": "Database",
       "sortData": "Trier ?",
-      "constraint": "Contraintes",
+      "constraints": "Contraintes",
       "path": "Chemin",
       "output": "Sortie",
       "passThrough": "Transmettre ?",
@@ -21,7 +21,7 @@
       "tip0": "Vous pouvez utiliser des contraintes pour la requête en définissant la propriété <code>msg.method</code>.",
       "tip1": "Si <code>msg.method</code> est défini, les contraintes de la requête définies dans le noeuud seront remplacées par celles contenues dans le message."
     },
-    "useConstraint": "Souhaitez-vous trier et ordonner vos données ?",
+    "useConstraints": "Souhaitez-vous trier et ordonner vos données ?",
     "passThrough": "Si un message arrive, transmettre le message ?"
   }
 }

--- a/build/nodes/locales/fr/firebase-in.html
+++ b/build/nodes/locales/fr/firebase-in.html
@@ -19,6 +19,15 @@
 		Se connecte à une base de données en temps réel Firebase et s'abonne aux données du chemin spécifié. Vous pouvez
 		définir des contraintes pour la requête afin de trier et ordonner vos données.
 	</p>
+	<h3>Entrées</h3>
+	<dl class="message-properties">
+		<dt>listener<span class="property-type">chaîne de caractères</span></dt>
+		<dd>le type de changement que vous souhaitez écouter.</dd>
+		<dt class="optional">constraints<span class="property-type">objet</span></dt>
+		<dd>un objet contenant la ou les contraintes à appliquer à la requête.</dd>
+		<dt class="optional">topic<span class="property-type">chaîne de caractères</span></dt>
+		<dd>le chemin des données à lire. Par défaut 'topic'.</dd>
+	</dl>
 	<h3>Sorties</h3>
 	<dl class="message-properties">
 		<dt>payload<span class="property-type">chaîne | booléen | nombre | tableau | objet | nul</span></dt>
@@ -39,6 +48,7 @@
 	</p>
 	<p>L' <strong>Écouteur</strong> vous permet de choisir le type de changement que vous souhaitez écouter :</p>
 	<ul>
+		<li><code>- utiliser msg.listener -</code></li>
 		<li><code>Valeur</code></li>
 		<li><code>Enfant ajouté</code></li>
 		<li><code>Enfant modifié</code></li>
@@ -46,8 +56,9 @@
 		<li><code>Enfant supprimé</code></li>
 	</ul>
 	<p>
-		Le <strong>Chemin</strong> détermine où les données seront lues. Il peut être vide, dans ce cas les données envoyées
-		proviennent de la racine de la base de données.
+		Le <strong>Chemin</strong> détermine où les données seront lues. Il peut être défini dans le noeud ou dynamiquement
+		avec la propriété <code>msg.topic</code>. Il peut être vide, dans ce cas les données envoyées proviennent de la
+		racine de la base des données.
 	</p>
 	<p>
 		La <strong>Sortie</strong> peut être définie sur <strong>détection automatique</strong> pour envoyer un objet
@@ -56,7 +67,7 @@
 	</p>
 	<p>
 		Vous pouvez définir des contraintes pour la requête afin de trier et d'ordonner vos données. Vous pouvez définir une
-		ou plusieurs des contraintes suivantes dans la propriété <code>msg.method</code> ou directement dans le noeud :
+		ou plusieurs des contraintes suivantes dans la propriété <code>msg.constraints</code> ou directement dans le noeud :
 	</p>
 	<ul>
 		<li><code>endAt</code><span class="property-type">objet</span></li>
@@ -71,7 +82,7 @@
 		<li><code>startAfter</code><span class="property-type">objet</span></li>
 		<li><code>startAt</code><span class="property-type">objet</span></li>
 	</ul>
-	<p>Le <code>msg.method</code> ressemblera à ceci :</p>
+	<p>Le <code>msg.constraints</code> ressemblera à ceci :</p>
 	<pre>
 {
   "orderByChild": "nom",

--- a/build/nodes/locales/fr/firebase-in.json
+++ b/build/nodes/locales/fr/firebase-in.json
@@ -4,7 +4,7 @@
       "database": "Database",
       "listener": "Écouteur",
       "sortData": "Trier ?",
-      "constraint": "Contraintes",
+      "constraints": "Contraintes",
       "path": "Chemin",
       "output": "Sortie",
       "passThrough": "Transmettre ?",
@@ -25,7 +25,7 @@
     "placeholder": {
       "name": "Nom"
     },
-    "useConstraint": "Souhaitez-vous trier et ordonner vos données ?",
+    "useConstraints": "Souhaitez-vous trier et ordonner vos données ?",
     "passThrough": "Si un message arrive, transmettre le message ?"
   }
 }

--- a/resources/constraints-container.js
+++ b/resources/constraints-container.js
@@ -7,11 +7,10 @@ const FirebaseQueryConstraintsContainer = (function () {
 	));
 
 	class EditableQueryConstraintsList {
-		// TODO: constraint to plural
 		constructor() {
 			this.containerId = "#node-input-constraints-container";
 			this.containerClass = ".node-input-constraints-container-row";
-			this.useConstraintsId = "#node-input-useConstraint";
+			this.useConstraintsId = "#node-input-useConstraints";
 			this.node = {};
 		}
 
@@ -27,8 +26,21 @@ const FirebaseQueryConstraintsContainer = (function () {
 		}
 
 		#constraintsHandler() {
+			// Legacy Config
+			if (this.node.useConstraint !== undefined) {
+				this.node.useConstraints = this.node.useConstraint;
+				this.useConstraints?.prop("checked", this.node.useConstraints);
+				delete this.node.useConstraint;
+			}
+
+			// Legacy Config
+			if (this.node.constraint !== undefined) {
+				this.node.constraints = this.node.constraint;
+				delete this.node.constraint;
+			}
+
 			if (this.useConstraints?.prop("checked") === true) {
-				const constraints = Object.entries(this.node.constraint || {});
+				const constraints = Object.entries(this.node.constraints || {});
 
 				if (!constraints.length) constraints.push(["limitToLast", 5]);
 
@@ -68,8 +80,7 @@ const FirebaseQueryConstraintsContainer = (function () {
 			const node = this.node;
 			this.container?.editableList("items").sort(compareItemsList);
 
-			// TODO: constraint to plural
-			this.node.constraint = {};
+			this.node.constraints = {};
 
 			this.container?.each(function () {
 				const constraintType = $(this).find("#node-input-constraint-type").typedInput("value");
@@ -96,7 +107,7 @@ const FirebaseQueryConstraintsContainer = (function () {
 							valueParsed = value;
 						}
 
-						node.constraint[constraintType] = { value: valueParsed, key: child, type: type };
+						node.constraints[constraintType] = { value: valueParsed, key: child, type: type };
 						break;
 					}
 					case "limitToFirst":
@@ -107,18 +118,18 @@ const FirebaseQueryConstraintsContainer = (function () {
 							valueParsed = value;
 						}
 
-						node.constraint[constraintType] = valueParsed;
+						node.constraints[constraintType] = valueParsed;
 						break;
 					}
 					case "orderByChild":
 						if (isChildValid(child, constraintType) !== true) RED.notify("Query Constraints: Setted value is not a valid child!", "error");
 						// TODO: check null or empty => invalid child
-						node.constraint[constraintType] = child;
+						node.constraints[constraintType] = child;
 						break;
 					case "orderByKey":
 					case "orderByPriority":
 					case "orderByValue":
-						node.constraint[constraintType] = null;
+						node.constraints[constraintType] = null;
 						break;
 				}
 			});

--- a/src/lib/types/firebase-config.ts
+++ b/src/lib/types/firebase-config.ts
@@ -56,13 +56,21 @@ export type BaseConfig = NodeDef & {
 };
 
 export type FirebaseGetConfig = BaseConfig & {
+	/**
+	 * @deprecated Replaced by `constraints`
+	 */
 	constraint?: QueryConstraint;
+	constraints?: QueryConstraint;
 	outputType?: OutputType;
 	passThrough?: boolean;
 };
 
 export type FirebaseInConfig = BaseConfig & {
+	/**
+	 * @deprecated Replaced by `constraints`
+	 */
 	constraint?: QueryConstraint;
+	constraints?: QueryConstraint;
 	listenerType?: ListenerType;
 	outputType?: OutputType;
 	passThrough?: boolean;


### PR DESCRIPTION
Below, what changed for the use of Query Constraints:

- Constraints defined in the node:

  - `node.constraint` becomes `node.constraints`
  - `node.useConstraint` becomes `node.useConstraints`

- Constraints defined dynamically:

`msg.method` becomes `msg.constraints`

**These changes are non-breaking: your flows will continue to work until you redeploy the changes**

BUT: the node validation will return an error!