### PR TITLE
(ServerValue) Relax Integer rule to Number and add `DECREMENT` keyword

### DIFF
--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -218,7 +218,8 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 	}
 
 	/**
-	 * Evaluates the payload message to replace reserved keywords (`TIMESTAMP` and `INCREMENT`) with the corresponding server value.
+	 * Evaluates the payload message to replace reserved keywords (`TIMESTAMP`, `INCREMENT` and `DECREMENT`) with
+	 * the corresponding server value.
 	 * @param payload The payload to be evaluated
 	 * @returns The payload evaluated
 	 */
@@ -231,14 +232,15 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 			case "string": {
 				if (/^\s*TIMESTAMP\s*$/.test(payload)) return ServerValue.TIMESTAMP;
 
-				if (/^\s*INCREMENT\s*-?\d+\.?\d*\s*$/.test(payload)) {
+				if (/^\s*(?:INCREMENT|DECREMENT)\s*-?\d+\.?\d*\s*$/.test(payload)) {
 					const deltaString = payload.match(/-?\d+\.?\d*/)?.[0] || "";
 					const delta = Number(deltaString);
 
-					if (Number.isNaN(delta) || !Number.isInteger(delta))
-						throw new Error("The delta of increment function must be an integer.");
+					if (Number.isNaN(delta))
+						throw new Error("The delta of increment function must be a valid number.");
 
-					return ServerValue.increment(delta);
+					const toOppose = /DECREMENT/.test(payload)
+					return ServerValue.increment(toOppose ? (- delta) : delta);
 				}
 
 				return payload;


### PR DESCRIPTION
This PR reinforces the initial integration of #51:

- Relax Integer rule to Number

  So the regex now accepts a number instead of an integer.

- Add `DECREMENT` keyword

  You can now use `DECREMENT 5` instead of `INCREMENT -5`