### PR TITLE
Feature: Add `env` field type to `Path`, `Child` and `Value` inputs

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -37,7 +37,7 @@ const FirebaseUI = (function () {
 		},
 		childType: function () {
 			return function (value, opt) {
-				if (typeof value === "string" && /^(msg|str|flow|global|jsonata)$/.test(value)) return true;
+				if (typeof value === "string" && /^(msg|str|flow|global|jsonata|env)$/.test(value)) return true;
 				if (opt?.label) return i18n("errors.invalid-type-prop", { prop: opt.label });
 				return opt ? i18n("errors.invalid-type") : false;
 			};
@@ -73,7 +73,7 @@ const FirebaseUI = (function () {
 		},
 		pathType: function () {
 			return function (value, opt) {
-				if (typeof value === "string" && /^(msg|str|flow|global|jsonata)$/.test(value)) return true;
+				if (typeof value === "string" && /^(msg|str|flow|global|jsonata|env)$/.test(value)) return true;
 				if (opt?.label) return i18n("errors.invalid-type-prop", { prop: opt.label });
 				return opt ? i18n("errors.invalid-type") : false;
 			};
@@ -140,7 +140,7 @@ const FirebaseUI = (function () {
 		},
 		valueType: function () {
 			return (value, opt) => {
-				if (/^(bool|date|flow|global|jsonata|msg|null|num|str)$/.test(value)) return true;
+				if (/^(bool|date|flow|global|jsonata|env|msg|null|num|str)$/.test(value)) return true;
 				if (opt?.label) return i18n("errors.invalid-type-prop", { prop: opt.label });
 				return opt ? i18n("errors.invalid-type") : false;
 			};
@@ -304,7 +304,7 @@ const FirebaseUI = (function () {
 		build() {
 			const others = this._autoComplete ? { autoComplete: autoComplete() } : {};
 			this.staticFieldOptions = [{ value: "str", label: "string", icon: "red/images/typedInput/az.svg", validate: validators.path(this._allowBlank), ...others }];
-			this.dynamicFieldOptions = [...this.staticFieldOptions, "msg", "flow", "global", "jsonata"];
+			this.dynamicFieldOptions = [...this.staticFieldOptions, "msg", "flow", "global", "jsonata", "env"];
 			this.pathField.typedInput({
 				typeField: "#node-input-pathType",
 				types: this._modeByDefault === "dynamic" ? this.dynamicFieldOptions : this.staticFieldOptions,

--- a/resources/constraints-container.js
+++ b/resources/constraints-container.js
@@ -22,7 +22,7 @@ const FirebaseQueryConstraintsContainer = (function () {
 		{ value: fieldName, label: i18n(`constraint.${fieldName}`) }
 	));
 
-	const dynamicFieldTypes = ["msg", "flow", "global", "jsonata"];
+	const dynamicFieldTypes = ["msg", "flow", "global", "jsonata", "env"];
 	const limitFieldTypes = [{ value: "num", label: "number", icon: "red/images/typedInput/09.svg", validate: FirebaseUI.validators.priority() }, ...dynamicFieldTypes];
 	const rangeFieldTypes = ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }, ...dynamicFieldTypes];
 

--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -135,10 +135,10 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 		const [value, type, msg] = args;
 		const typesAllowed =
 			field === "child"
-				? ["flow", "global", "jsonata", "msg", "str"]
+				? ["flow", "global", "jsonata", "env", "msg", "str"]
 				: field === "value"
-					? ["bool", "date", "flow", "global", "jsonata", "msg", "null", "num", "str"]
-					: ["flow", "global", "jsonata", "msg", "num"];
+					? ["bool", "date", "flow", "global", "jsonata", "env", "msg", "null", "num", "str"]
+					: ["flow", "global", "jsonata", "env", "msg", "num"];
 
 		if (!typesAllowed.includes(type))
 			throw new Error(`Invalid type (${type}) for the ${field} field. Please reconfigure this node.`);
@@ -207,7 +207,7 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 		// TODO: Remove Me
 		if (this.isFirebaseInNode(this.node) && type === undefined) type = "str";
 
-		if (!["flow", "global", "jsonata", "msg", "str"].includes(type!))
+		if (!["flow", "global", "jsonata", "env", "msg", "str"].includes(type!))
 			throw new Error(`Invalid type (${type}) for the Path field. Please reconfigure this node.`);
 
 		if (!msg && this.dynamicFieldTypes.includes(type!))


### PR DESCRIPTION
Add `env` (environment variable) field type to:
- `Path` input
- `Child` and `Value` inputs (Query Constraints)

Completes #65.