### PR TITLE
Fix the value of the `date` option for the field type

### DIFF
--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -145,9 +145,6 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 
 		let valueFound;
 		switch (type) {
-			case "date":
-				valueFound = Date.now();
-				break;
 			case "null":
 				valueFound = null;
 				break;


### PR DESCRIPTION
Node-RED v4 introduced a small new feature to add options to the `date` type (TypedInput). It's therefore necessary to get the final value according to the option.

Since v4 and earlier versions of Node-RED support the `date` type in the `RED.util.evaluateNodeProperty` function, let's use it directly.