### PR TITLE
Check if the required Config Node version is satisfied

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # Ensure the required version is up to date
+      - name: Update the Required Config Node version
+        run: node ./scripts/update-required-config-node-version.js
+
       - name: Build
         run: npm run build
 

--- a/resources/migration.js
+++ b/resources/migration.js
@@ -379,7 +379,7 @@
 		const restartAfterUpdateMsg = `
 			<html>
 				<p>Don't forget to restart Node-RED!</p>
-				<p>It looks like you didn't restart Node-RED after running the Update script.</p>
+				<p>It looks like you didn't restart Node-RED after running the Update script 🙄</p>
 			</html>`;
 
 		let msg;

--- a/scripts/update-required-config-node-version.js
+++ b/scripts/update-required-config-node-version.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright 2023-2024 Gauthier Dandele
+ *
+ * Licensed under the MIT License,
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { join } = require("node:path");
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+
+const filePath = "src/migration/config-node.ts";
+
+const versionRegex = /requiredVersion = \[([0-9], [0-9]+, [0-9]+)\]/;
+
+try {
+	console.log("Check if the required Config Node version is up to date...");
+
+	const packageFile = require("../package.json");
+	const destinationFilePath = join(__dirname, "../", filePath);
+
+	if (existsSync(destinationFilePath)) {
+		const destinationFile = readFileSync(destinationFilePath, { encoding: "utf8" });
+
+		const requiredVersionString = packageFile.dependencies["@gogovega/firebase-config-node"];
+
+		const requiredVersionRow = /([0-9]\.[0-9]+\.[0-9]+)/.exec(requiredVersionString);
+		const currentVersionRow = versionRegex.exec(destinationFile);
+
+		if (requiredVersionRow && currentVersionRow) {
+			const requiredVersion = requiredVersionRow[1].replace(/\./g, ", ");
+			const currentVersion = currentVersionRow[1];
+
+			console.log(`Current version:  [${currentVersion}]\nRequired Version: [${requiredVersion}]`);
+
+			if (currentVersion !== requiredVersion) {
+				const contentToWrite = destinationFile.replace(versionRegex, `requiredVersion = [${requiredVersion}]`);
+				console.log("Writing...");
+				writeFileSync(destinationFilePath, contentToWrite, { encoding: "utf8" });
+				console.log("Write done");
+			} else {
+				console.log("The required version is up to date");
+			}
+		}
+	}
+
+	console.log("Done.");
+} catch (error) {
+	console.error("An error occurred while updating:", error);
+}

--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -44,6 +44,7 @@ import {
 	QueryConstraintPropertySignature,
 } from "./types";
 import { checkPath, checkPriority, printEnumKeys } from "./utils";
+import { checkConfigNodeSatisfiesVersion } from "../migration/config-node";
 
 /**
  * Firebase Class
@@ -100,6 +101,15 @@ export class Firebase<Node extends FirebaseNode, Config extends FirebaseConfig =
 
 		if (!isFirebaseConfigNode(node.database) && node.database)
 			throw new Error("The selected database is not compatible with this module, please check your config-node");
+
+		if (node.database) {
+			if (!checkConfigNodeSatisfiesVersion(RED, node.database.version)) {
+				node.status({ fill: "red", shape: "ring", text: "Invalid Database Version!" });
+
+				// To avoid initializing the database (avoid creating unhandled errors)
+				node.database = null;
+			}
+		}
 	}
 
 	/**

--- a/src/migration/config-node.ts
+++ b/src/migration/config-node.ts
@@ -83,7 +83,7 @@ function checkConfigNodeSatisfiesVersion(RED: NodeAPI, version: string): boolean
 
 type Exec = Record<"run", (command: string, args: string[], option: object, emit: boolean) => Promise<object>>;
 
-async function runUpdateDependencies(RED: NodeAPI, exec: Exec) {
+function runUpdateDependencies(RED: NodeAPI, exec: Exec): Promise<object> {
 	const isWindows = process.platform === "win32";
 	const npmCommand = isWindows ? "npm.cmd" : "npm";
 	const extraArgs = [
@@ -98,17 +98,7 @@ async function runUpdateDependencies(RED: NodeAPI, exec: Exec) {
 	const args = ["update", ...extraArgs];
 	const userDir = RED.settings.userDir || process.env.NODE_RED_HOME || ".";
 
-	RED.log.info("Starting to update Node-RED dependencies...");
-
-	try {
-		await exec.run(npmCommand, args, { cwd: userDir, shell: true }, true);
-
-		RED.log.info("Successfully updated Node-RED dependencies. Please restarts Node-RED.");
-	} catch (error) {
-		const err = (error as Record<"stderr", string>).stderr;
-		RED.log.error("An error occured while updating Node-RED dependencies: " + err);
-		throw error;
-	}
+	return exec.run(npmCommand, args, { cwd: userDir, shell: true }, true);
 }
 
 function versionIsSatisfied(): boolean {

--- a/src/nodes/load-config.ts
+++ b/src/nodes/load-config.ts
@@ -16,79 +16,64 @@
 
 import { ConfigNode } from "@gogovega/firebase-config-node/types";
 import { NodeAPI } from "node-red";
-import { researchConfigNodeExistence, runInstallScript } from "../migration/config-node";
+import { join } from "node:path";
+import { runUpdateDependencies, versionIsSatisfied } from "../migration/config-node";
 
 /**
- * This fake node is used:
- * 1. To check the existence of the config-node See {@link researchConfigNodeExistence}
- * 2. An endpoint for nodes to request services from
- *   - returns options to autocomplete the path field
- *   - Informs the user (notification) about the config-node status (has it been found)
+ * This fake node is used as:
+ * An endpoint for nodes to request services from
+ *   - Returns options to autocomplete the path field
+ *   - Informs the editor about the config-node status
+ *   - Run a command to update NR dependencies
  *
  * Hosted services such as FlowFuse do not use a file system - so it's not possible to run the Migrate script
  * from the runtime.
  */
 module.exports = function (RED: NodeAPI) {
-	const configNodeStatus = {
-		configNode: researchConfigNodeExistence(RED),
-		installCalled: false,
-	};
+	let updateScriptCalled: boolean = false;
 
+	// Check if the Config Node version satisfies the require one
 	RED.httpAdmin.get("/firebase/rtdb/config-node/status", RED.auth.needsPermission("load-config.write"), (_req, res) => {
-		const notifications = [];
-
-		// Install Script
-		if (!configNodeStatus.configNode?.found && !configNodeStatus.installCalled) {
-			const msgInstallFromFile = `
-					<html>
-						<p>Welcome to Migration Wizard</p>
-						<p>In order to use the new config-node introduced by v0.6, please run the installation script</p>
-						<p>Read more about this migration <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
-					</html>`;
-			const msgInstallFromNPM = `
-					<html>
-						<p>Welcome to Migration Wizard</p>
-						<p>In order to use the new config-node introduced by v0.6, please run the installation script</p>
-						<p>Or run the following command in your terminal:</p>
-						<pre>cd ${configNodeStatus.configNode?.dir} && ${configNodeStatus.configNode?.install}</pre>
-						<p>Read more about this migration <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
-					</html>`;
-			const msgIfScriptNotRunnable = `
-					<html>
-						<p>Welcome to Migration Wizard</p>
-						<p>The new config-node introduced by v0.6 did not load correctly.</p>
-						<p>It looks like your user directory is not the default, please complete paths and run the following command:</p>
-						<pre>cd ${configNodeStatus.configNode?.dir} && ${configNodeStatus.configNode?.install}</pre>
-						<p>Or If you know the path to the module run the following command:</p>
-						<pre>cd ${configNodeStatus.configNode?.dir} && npm install file:/path/to/firebase-config-node --save</pre>
-						<p>Read more about this migration <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/discussions/50">here</a>.</p>
-					</html>`;
-
-			const scriptRunnable = configNodeStatus.configNode?.userDirValid;
-			const msg = scriptRunnable
-				? configNodeStatus.configNode?.valide
-					? msgInstallFromFile
-					: msgInstallFromNPM
-				: msgIfScriptNotRunnable;
-			const buttons = scriptRunnable ? ["Run Install", "Close"] : ["Close"];
-
-			// Avoid spamming the user because this case should not happen
-			if (!scriptRunnable) configNodeStatus.installCalled = true;
-
-			notifications.push({
-				msg: msg,
-				type: "warning",
-				fixed: true,
-				modal: true,
-				buttons: buttons,
-			});
-		}
-
 		res.json({
-			status: !notifications.length ? "ready" : "error",
-			notifications: notifications,
+			status: {
+				versionIsSatisfied: versionIsSatisfied(),
+				updateScriptCalled: updateScriptCalled,
+			},
 		});
 	});
+
+	// Run the Update Script
+	RED.httpAdmin.post(
+		"/firebase/rtdb/config-node/scripts",
+		RED.auth.needsPermission("load-config.write"),
+		async (req, res) => {
+			try {
+				const scriptName = req.body.script;
+
+				if (scriptName === "update-dependencies") {
+					updateScriptCalled = true;
+
+					// @node-red/util.exec is not exported, so it's a workaround to get it
+					const utilPath = join(process.env.NODE_RED_HOME || ".", "node_modules", "@node-red/util");
+					// eslint-disable-next-line @typescript-eslint/no-require-imports
+					const exec = require(utilPath).exec;
+
+					await runUpdateDependencies(RED, exec);
+				} else {
+					// Forbidden
+					res.sendStatus(403);
+					return;
+				}
+
+				res.json({ status: "success" });
+			} catch (error) {
+				res.json({
+					status: "error",
+					msg: error instanceof Error ? error.toString() : (error as Record<"stderr", string>).stderr,
+				});
+			}
+		}
+	);
 
 	// Get autocomplete options
 	RED.httpAdmin.get(
@@ -110,52 +95,6 @@ module.exports = function (RED: NodeAPI) {
 			const options = typeof data === "object" ? Object.keys(data ?? {}) : [];
 
 			return res.json(options);
-		}
-	);
-
-	// Run the Install Script
-	RED.httpAdmin.post(
-		"/firebase/rtdb/config-node/scripts",
-		RED.auth.needsPermission("load-config.write"),
-		async (req, res) => {
-			try {
-				const script = req.body.script;
-
-				if (script === "install") {
-					configNodeStatus.installCalled = true;
-
-					if (!configNodeStatus.configNode?.dir || !configNodeStatus.configNode?.install)
-						throw new Error("Node-RED Settings not available");
-
-					await runInstallScript(configNodeStatus.configNode.dir, configNodeStatus.configNode.install);
-				} else {
-					res.sendStatus(403);
-					return;
-				}
-
-				res.json({
-					notifications: [
-						{
-							msg: "<html><p>Migration Successful!</p><p>Restarts now Node-RED and reload your browser</p></html>",
-							type: "success",
-							fixed: true,
-							buttons: ["Close"],
-						},
-					],
-				});
-			} catch (error) {
-				console.error("Error during Migration", error);
-				res.json({
-					notifications: [
-						{
-							msg: '<html><p>Migration Failed!</p><p>Please raise an issue <a href="https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/issues/new/choose">here</a> with log details</p></html>',
-							type: "error",
-							fixed: true,
-							buttons: ["Close"],
-						},
-					],
-				});
-			}
 		}
 	);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
+    "stripInternal": true,
   },
   "include": [
     "src"


### PR DESCRIPTION
TL;DR - Remove Install Script and replace by the Update Script.

The Install Script was based on the idea that NR might fail to load the Config Node. This script trying to find where the Config Node package was installed and suggest a command to the user to run so that NR could load it. A notification system in the editor also allowed this to be done automatically.

Since NR is able to load it after a reboot (because it does a deep scan) this script is no longer needed.

But, the first tests with the Cloud Firestore palette have highlighted a new problem: when installing the RTDB palette if the Cloud Firestore palette is already installed (or vice versa) NPM installs a new Config Node package inside the package it installs. NR cannot therefore load this new package and will load the existing one. Which leads to a version conflict...

To solve this problem, the user must update the NR dependencies.

Of course, a notification system has been added to automate things :wink: