### PR TITLE
Move all `name` fields to the top of the edit box

### DIFF
--- a/build/nodes/firebase-get.html
+++ b/build/nodes/firebase-get.html
@@ -65,6 +65,11 @@
 
 <script type="text/html" data-template-name="firebase-get">
 	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-get.label.name"></span></label>
+		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-get.placeholder.name" />
+	</div>
+
+	<div class="form-row">
 		<label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="firebase-get.label.database"></span></label>
 		<input type="text" id="node-input-database" style="width:70%;" />
 	</div>
@@ -98,11 +103,6 @@
 		<label for="node-input-passThrough"></label>
 		<input type="checkbox" id="node-input-passThrough" style="display:inline-block; width:15px; vertical-align:baseline;" />
 		<span data-i18n="firebase-get.passThrough"></span>
-	</div>
-
-	<div class="form-row">
-		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-get.label.name"></span></label>
-		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-get.placeholder.name" />
 	</div>
 
 	<div class="form-tips" id="firebase-get-tips">

--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -74,6 +74,11 @@
 
 <script type="text/html" data-template-name="firebase-in">
 	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-in.label.name"></span></label>
+		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-in.placeholder.name" />
+	</div>
+
+	<div class="form-row">
 		<label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="firebase-in.label.database"></span></label>
 		<input type="text" id="node-input-database" style="width:70%;" />
 	</div>
@@ -120,10 +125,5 @@
 		<label for="node-input-passThrough"></label>
 		<input type="checkbox" id="node-input-passThrough" style="display:inline-block; width:15px; vertical-align:baseline;" />
 		<span data-i18n="firebase-in.passThrough"></span>
-	</div>
-
-	<div class="form-row">
-		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-in.label.name"></span></label>
-		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-in.placeholder.name" />
 	</div>
 </script>

--- a/build/nodes/firebase-out.html
+++ b/build/nodes/firebase-out.html
@@ -80,6 +80,11 @@
 
 <script type="text/html" data-template-name="firebase-out">
 	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-out.label.name"></span></label>
+		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-out.placeholder.name" />
+	</div>
+
+	<div class="form-row">
 		<label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="firebase-out.label.database"></span></label>
 		<input type="text" id="node-input-database" style="width:70%;" />
 	</div>
@@ -107,11 +112,6 @@
 		<label for="node-input-path"><i class="fa fa-sitemap"></i> <span data-i18n="firebase-out.label.path"></span></label>
 		<input type="text" id="node-input-path" style="width:70%;" />
 		<input type="hidden" id="node-input-pathType" />
-	</div>
-
-	<div class="form-row">
-		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="firebase-out.label.name"></span></label>
-		<input type="text" id="node-input-name" data-i18n="[placeholder]firebase-out.placeholder.name" />
 	</div>
 
 	<div class="form-tips" id="firebase-out-tips">

--- a/build/nodes/on-disconnect.html
+++ b/build/nodes/on-disconnect.html
@@ -76,6 +76,11 @@
 
 <script type="text/html" data-template-name="on-disconnect">
 	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="on-disconnect.label.name"></span></label>
+		<input type="text" id="node-input-name" data-i18n="[placeholder]on-disconnect.placeholder.name" />
+	</div>
+
+	<div class="form-row">
 		<label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="on-disconnect.label.database"></span></label>
 		<input type="text" id="node-input-database" style="width:70%;" />
 	</div>
@@ -104,10 +109,5 @@
 		<label for="node-input-sendMsgEvent"><i class="fa fa-sign-out"></i> <span data-i18n="on-disconnect.label.sendMsgEvent"></span></label>
 		<input type="text" id="node-input-sendMsgEvent" style="width:70%;" />
 		<input type="hidden" id="node-input-outputs" />
-	</div>
-
-	<div class="form-row">
-		<label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="on-disconnect.label.name"></span></label>
-		<input type="text" id="node-input-name" data-i18n="[placeholder]on-disconnect.placeholder.name" />
 	</div>
 </script>


### PR DESCRIPTION
This change reflects the "new" standard of putting the Name field first.

## Before:

<img width="509" alt="edit-box-before" src="https://github.com/user-attachments/assets/8297c100-845c-462e-b803-815a7a15a906">

## After:

<img width="509" alt="edit-box-after" src="https://github.com/user-attachments/assets/3c05ae08-c7cb-4d63-9f3e-b39ac7c94233">
