### PR TITLE
Fix autocomplete crash if database get request fails

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -189,7 +189,7 @@ var FirebaseUI = FirebaseUI || (function () {
 				}
 			}
 
-			const url = `firebase/rtdb/autocomplete/${configNodeId}?path=${encodeURIComponent(searchKey)}`;
+			const url = `firebase/rtdb/autocomplete/${configNodeId}${searchKey ? `?path=${encodeURIComponent(searchKey)}` : ""}`;
 
 			if (contextCache[url]) {
 				done();


### PR DESCRIPTION
Node-RED crash if autocomplete do a request and fails. Like Permission Denied.

And also:
- Slight rewrite
- Decode path in backend