### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log
 
+## 0.7.0
+
+### Breaking Changes
+
+- Set required version of Node.js to >=18
+
+### Changes
+
+- Bump `@gogovega/firebase-config-node` from 0.1.5 to 0.2.0
+  - Only don't wait signout for Firestore and add a safety delay ([#12](https://github.com/GogoVega/Firebase-Config-Node/pull/12))
+  - Set required version of Node.js to >=18
+  - Set required version of Node-RED to >=3
+
 ## 0.6.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@
 ![demo nodes](./assets/images/demo-flow.gif)
 
 > [!CAUTION]
-> **BREAKING CHANGES**: If you are updating to 0.6, please read the [migration procedure](https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/migration-wizard).
+> **BREAKING CHANGES**: v0.7.0: the required version of Node.js is now >=18
+
+> [!CAUTION]
+> **BREAKING CHANGES**: If you are updating to v0.6, please read the [migration procedure](https://github.com/GogoVega/node-red-contrib-firebase-realtime-database/wiki/migration-wizard).
 
 ## What is it?
 
@@ -82,7 +85,7 @@ cd ~/.node-red
 npm install @gogovega/node-red-contrib-firebase-realtime-database --omit=dev
 ```
 
-Remember to restart Node RED after using either method. 
+Remember to restart Node RED after using either method.
 
 ## Authentication Methods
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@gogovega/firebase-config-node": "^0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,27 +9,27 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@gogovega/firebase-config-node": "^0.1.5"
+        "@gogovega/firebase-config-node": "^0.2.0"
       },
       "devDependencies": {
         "@types/node-red": "^1.3.5",
-        "@typescript-eslint/eslint-plugin": "^8.7.0",
-        "@typescript-eslint/parser": "^8.7.0",
+        "@typescript-eslint/eslint-plugin": "^8.11.0",
+        "@typescript-eslint/parser": "^8.11.0",
         "eslint": "^8.57.1",
         "mocha": "^10.7.3",
-        "node-red": "^4.0.3",
+        "node-red": "^4.0.5",
         "node-red-node-test-helper": "^0.3.4",
         "prettier": "^3.3.3",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.3"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
-      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-E7Vgw78I93we4ZWdYCb4DGAwRROGkMIXk7/y87UmANR+J6qsWusmC3gLt0H+O0KOt5e6O38U8oJamgbudrES/w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -74,25 +74,28 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.2.tgz",
+      "integrity": "sha512-2WwyTYNVaMNUWPZTOJdkax9iqTdirrApgTbk+Qoq5EPX6myqZvG8QGFRgdKmkjKVG6/G/a565vpPauHk0+hpBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -164,16 +167,19 @@
       "license": "MIT"
     },
     "node_modules/@firebase/app": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.11.tgz",
-      "integrity": "sha512-DuI8c+p/ndPmV6V0i+mcSuaU9mK9Pi9h76WOYFkPNsbmkblEy8bpTOazjG7tnfar6Of1Wn5ohvyOHSRqnN6flQ==",
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.15.tgz",
+      "integrity": "sha512-he6qlG3pmwL+LHdG/BrSMBQeJzzutciq4fpXN3lGa1uSwYSijJ24VtakS/bP2X9SiDf8jGywJ4u+OgXAenJsNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
@@ -189,16 +195,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
-      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.8.0.tgz",
+      "integrity": "sha512-/O7UDWE5S5ux456fzNHSLx/0YN/Kykw/WyAzgDQ6wvkddZhSEmPX19EzxgsFldzhuFjsl5uOZTz8kzlosCiJjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -217,28 +225,34 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
-      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.10.tgz",
+      "integrity": "sha512-OsNbEKyz9iLZSmMUhsl6+kCADzte00iisJIRUspnUqvDCX+RSGZOBIqekukv/jN177ovjApBQNFaxSYIDc/SyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.10.0",
+        "@firebase/util": "1.10.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
-      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.9.tgz",
+      "integrity": "sha512-EkiPSKSu2TJJGtOjyISASf3UFpFJDil1lMbfqnxilfbmIsilvC8DzgjuLoYD+eOitcug4wtU9Fh1tt2vgBhskA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/database-compat": {
@@ -255,6 +269,49 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@firebase/database-compat/node_modules/@firebase/component": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat/node_modules/@firebase/database": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat/node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat/node_modules/@firebase/util": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@firebase/database-types": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
@@ -265,38 +322,7 @@
         "@firebase/util": "1.10.0"
       }
     },
-    "node_modules/@firebase/firestore": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.2.tgz",
-      "integrity": "sha512-WPkL/DEHuJg1PZPyHn81pNUhitG+7WkpLVdXmoYB23Za3eoM8VzuIn7zcD4Cji6wDCGA6eI1rvGYLtsXmE1OaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "@firebase/webchannel-wrapper": "1.0.1",
-        "@grpc/grpc-js": "~1.9.0",
-        "@grpc/proto-loader": "^0.7.8",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/logger": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
-      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/util": {
+    "node_modules/@firebase/database-types/node_modules/@firebase/util": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
       "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
@@ -305,27 +331,72 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@firebase/firestore": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.4.tgz",
+      "integrity": "sha512-K2nq4w+NF8J1waGawY5OHLawP/Aw5CYxyDstVv1NZemGPcM3U+LZ9EPaXr1PatYIrPA7fS4DxZoWcbB0aGJ8Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
+        "@firebase/webchannel-wrapper": "1.0.2",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.3.tgz",
+      "integrity": "sha512-Th42bWJg18EF5bJwhRosn2M/eYxmbWCwXZr4hHX7ltO0SE3QLrpgiMKeRBR/NW7vJke7i0n3i8esbCW2s93qBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.1.tgz",
+      "integrity": "sha512-AIhFnCCjM8FmCqSNlNPTuOk3+gpHC1RkeNUBLtPbcqGYpN5MxI5q7Yby+rxycweOZOCboDzfIj8WyaY4tpQG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
-      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.2.tgz",
+      "integrity": "sha512-3F4iA2E+NtdMbOU0XC1cHE8q6MqpGIKRj62oGOF38S6AAx5VHR9cXmoDUSj7ejvTAT7m6jxuEeQkHeq0F+mU2w==",
       "license": "Apache-2.0"
     },
     "node_modules/@gogovega/firebase-config-node": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.5.tgz",
-      "integrity": "sha512-Com8lzKwkaIOTw7DhkmEmgdTXou5Rc8qASKztLCj5xF+D7m0cvUrvaI74ymZMAaVV8riL95McqVomoGdZtGJFg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.2.0.tgz",
+      "integrity": "sha512-uKGHhx3I63dO2ajS6OWqFZXfKZAQoGdUuzqPEx/pufvHGyj1K05gzvNZ1coO3cR5FtSXnnDn17iQq66ycEWjEQ==",
       "license": "MIT",
       "dependencies": {
-        "@firebase/app": "0.10.11",
-        "@firebase/auth": "1.7.9",
-        "@firebase/database": "1.0.8",
-        "@firebase/firestore": "4.7.2",
-        "firebase-admin": "^12.5.0",
+        "@firebase/app": "0.10.15",
+        "@firebase/auth": "1.8.0",
+        "@firebase/database": "1.0.9",
+        "@firebase/firestore": "4.7.4",
+        "firebase-admin": "^12.7.0",
         "tiny-typed-emitter": "^2.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/firestore": {
@@ -637,9 +708,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
-      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.5.tgz",
+      "integrity": "sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -650,20 +721,20 @@
       }
     },
     "node_modules/@node-red/editor-api": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-4.0.3.tgz",
-      "integrity": "sha512-neNj/CtCv9gfwWvSY2r/8U259hWrq2yX9t+Pe4lxfCdiBHm0/CUBs8xLHqqz3dBucQNK0ahRxCfBwWhI9AyKhA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-4.0.5.tgz",
+      "integrity": "sha512-X+c/v+HbAjBefqNPiPKA6k7R+MWuYRKB5+n7I23aF+GYEI/ExbbC4A0IXGKVXE0vrdZb1ffAWl0Xx8jldZMJfA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@node-red/editor-client": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/editor-client": "4.0.5",
+        "@node-red/util": "4.0.5",
         "bcryptjs": "2.4.3",
         "body-parser": "1.20.3",
         "clone": "2.1.2",
         "cors": "2.8.5",
-        "express": "4.21.0",
-        "express-session": "1.18.0",
+        "express": "4.21.1",
+        "express-session": "1.18.1",
         "memorystore": "1.6.7",
         "mime": "3.0.0",
         "multer": "1.4.5-lts.1",
@@ -679,16 +750,16 @@
       }
     },
     "node_modules/@node-red/editor-client": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-4.0.3.tgz",
-      "integrity": "sha512-mnfLU6iOUNdzrrHt6XYnVfZPixWrKDOmMfbz+USJR2JgAC25DLuezIIlTgA6FAbNaG3dXAsCN0mCQUw/7nV9cQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-4.0.5.tgz",
+      "integrity": "sha512-ZeM4Nbyg6bCmyWIzKhGjH3VFOmSmuPmFLK7Z7a/8lHY5Qs4fj9GvdWjcjXp+8q030ydVd4WF38PXRMu87GqiaQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@node-red/nodes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-4.0.3.tgz",
-      "integrity": "sha512-bds0KpzTT2QXmTuchekyOLf6H0O44lDfBIcfIZu6CLIPVD6yW+8joXQKBcbfpdPzprDlygIIcBTni1tTgQASwA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-4.0.5.tgz",
+      "integrity": "sha512-YEIt2KK1/2Z/Had23RXcVH2WMD2nZlIRz2Ds981LUBZr6zpSZDEoKwiyBE1Lqnrrs7dwVYNXS7CA1KjdajzLiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -698,14 +769,14 @@
         "body-parser": "1.20.3",
         "cheerio": "1.0.0-rc.10",
         "content-type": "1.0.5",
-        "cookie": "0.6.0",
-        "cookie-parser": "1.4.6",
+        "cookie": "0.7.2",
+        "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "cronosjs": "1.7.1",
         "denque": "2.1.0",
         "form-data": "4.0.0",
         "fs-extra": "11.2.0",
-        "got": "12.6.0",
+        "got": "12.6.1",
         "hash-sum": "2.0.0",
         "hpagent": "1.2.0",
         "https-proxy-agent": "5.0.1",
@@ -718,11 +789,24 @@
         "mustache": "4.2.0",
         "node-watch": "0.7.4",
         "on-headers": "1.0.2",
-        "raw-body": "2.5.2",
+        "raw-body": "3.0.0",
         "tough-cookie": "^5.0.0",
         "uuid": "9.0.1",
         "ws": "7.5.10",
         "xml2js": "0.6.2"
+      }
+    },
+    "node_modules/@node-red/nodes/node_modules/acorn": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/@node-red/nodes/node_modules/agent-base": {
@@ -791,57 +875,41 @@
       }
     },
     "node_modules/@node-red/registry": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-4.0.3.tgz",
-      "integrity": "sha512-2+v5MyP4C4cokRGNuBiDZMBd6k8cu3SHMPEt6Cby/CaTk9MlPzEdReAHq5wlzno/0nBTu9fN1ITbRD9Rd+M59w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-4.0.5.tgz",
+      "integrity": "sha512-bAt1gWibjYoIttyi8YPFgWIXNMdNXm1SjGc7Jag7tlDiLrYn0m8MJDO8OyVDp/xzFQ2rePtVZtdoa1SDMhrB2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@node-red/util": "4.0.3",
+        "@node-red/util": "4.0.5",
         "clone": "2.1.2",
         "fs-extra": "11.2.0",
-        "semver": "7.5.4",
-        "tar": "7.2.0",
+        "semver": "7.6.3",
+        "tar": "7.4.3",
         "uglify-js": "3.17.4"
       }
     },
-    "node_modules/@node-red/registry/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@node-red/runtime": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-4.0.3.tgz",
-      "integrity": "sha512-ftPOkDh9jPLFrxiF3kycKrU61lSjSws1Qv44gEoihvcqwujMIFhuSA14XOXn9St+nPSuaglI8Ud7XShdFtt22g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-4.0.5.tgz",
+      "integrity": "sha512-6CDJsY8zUMn+fzgAEEe+rS/FgQEoMPhNZzS1f4QjGn8uLUSyBfrCwxlHQwRCue/s26IxdMKUr7qqJkqnH7ASxw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@node-red/registry": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/registry": "4.0.5",
+        "@node-red/util": "4.0.5",
         "async-mutex": "0.5.0",
         "clone": "2.1.2",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "fs-extra": "11.2.0",
         "json-stringify-safe": "5.0.1",
         "rfdc": "^1.3.1"
       }
     },
     "node_modules/@node-red/util": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-4.0.3.tgz",
-      "integrity": "sha512-jR+/+luAAxblGDagrKsoh81xfpteofU6LnQxuVTyY2ecJ/JidmtYorlL+UeF479E2+uyZEi/w1fafsTJ09Jokw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-4.0.5.tgz",
+      "integrity": "sha512-g0czs4jKpWPx7auvBbz9MSCEL/f9/xlQMCHTYB2qbV+rouvBQS3ygaUI9Lqx2n9rYbdFm0BKteWVyznP/Vzhvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -851,7 +919,7 @@
         "jsonata": "2.0.5",
         "lodash.clonedeep": "^4.5.0",
         "moment": "2.30.1",
-        "moment-timezone": "0.5.45"
+        "moment-timezone": "0.5.46"
       }
     },
     "node_modules/@node-rs/bcrypt": {
@@ -1389,9 +1457,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
-      "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.1.tgz",
+      "integrity": "sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1415,9 +1483,9 @@
       "license": "MIT"
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.31.tgz",
-      "integrity": "sha512-rf/iB+cPJ/YZfMwr+FVuQbm7IaWC4y3FVYfVDxRGqmUCFjjPII0HWaP0vTPJGp6m4o13AXySCcMbWfrWtBFAKw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1447,12 +1515,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "version": "22.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
+      "integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/node-red": {
@@ -1556,9 +1624,9 @@
       "license": "MIT"
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
-      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.16.tgz",
+      "integrity": "sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1587,15 +1655,16 @@
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "^2.1.12",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -1623,9 +1692,9 @@
       }
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
-      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1647,17 +1716,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
-      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/type-utils": "8.7.0",
-        "@typescript-eslint/utils": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1681,16 +1750,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
-      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/typescript-estree": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1710,14 +1779,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
-      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0"
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1728,14 +1797,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
-      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.7.0",
-        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1753,9 +1822,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
-      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1767,14 +1836,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
-      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1796,16 +1865,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
-      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/typescript-estree": "8.7.0"
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1819,13 +1888,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
-      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/types": "8.11.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1878,9 +1947,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2230,6 +2299,22 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2645,9 +2730,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2655,27 +2740,17 @@
       }
     },
     "node_modules/cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "0.4.1",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.6"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -3138,6 +3213,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3339,9 +3415,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3350,7 +3426,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3382,13 +3458,13 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
-      "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "0.6.0",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
         "debug": "2.6.9",
         "depd": "~2.0.0",
@@ -3424,6 +3500,16 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -3531,11 +3617,11 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.0",
@@ -3662,14 +3748,14 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.5.0.tgz",
-      "integrity": "sha512-ad8vnlPcuuZN9scSgY8UnAxPI4mzP2/Q+dsrVLTf+j3h7bIq0FOelDCDGz4StgKJdk244v2kpOxqJjPG3grBHg==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "^1.0.2",
-        "@firebase/database-types": "^1.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
         "@types/node": "^22.0.1",
         "farmhash-modern": "^1.1.0",
         "jsonwebtoken": "^9.0.0",
@@ -3781,14 +3867,14 @@
       }
     },
     "node_modules/formidable": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
-      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
+        "hexoid": "^2.0.0",
         "once": "^1.4.0"
       },
       "funding": {
@@ -4020,9 +4106,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.1.tgz",
-      "integrity": "sha512-Rj+PMjoNFGFTmtItH7gHfbHpGVSb3vmnGK3nwNBqxQF9NoBpttSZI/rc0WiM63ma2uGDQtYEkMHkK9U6937NiA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
+      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4062,9 +4148,9 @@
       }
     },
     "node_modules/google-gax/node_modules/@grpc/grpc-js": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.3.tgz",
-      "integrity": "sha512-i9UraDzFHMR+Iz/MhFLljT+fCpgxZ3O6CxwGJ8YuNYHJItIHUzKJpW2LvoFZNnGPwqc9iWy9RAucxV0JoR9aUQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz",
+      "integrity": "sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4103,9 +4189,9 @@
       }
     },
     "node_modules/got": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
-      "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4243,9 +4329,9 @@
       "license": "MIT"
     },
     "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5374,9 +5460,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5661,24 +5747,24 @@
       }
     },
     "node_modules/node-red": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/node-red/-/node-red-4.0.3.tgz",
-      "integrity": "sha512-6ZYh54FKqkEANoFgUBNgHm4LaUg5m3eW/01Dslf3cf3aeaRPa9mpS63sRiFC75JuJCxN29LH1/As91/1lSOxYA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/node-red/-/node-red-4.0.5.tgz",
+      "integrity": "sha512-U//K/M/0EJrD80VPGmF+tHoMJVEykBBMgLmKPbKH9m0msXN1O/OC1VpGtyeUAGRwVsNQe0KgFNu6+G4JIguBcA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@node-red/editor-api": "4.0.3",
-        "@node-red/nodes": "4.0.3",
-        "@node-red/runtime": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/editor-api": "4.0.5",
+        "@node-red/nodes": "4.0.5",
+        "@node-red/runtime": "4.0.5",
+        "@node-red/util": "4.0.5",
         "basic-auth": "2.0.1",
         "bcryptjs": "2.4.3",
         "cors": "2.8.5",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "fs-extra": "11.2.0",
         "node-red-admin": "^4.0.1",
         "nopt": "5.0.0",
-        "semver": "7.5.4"
+        "semver": "7.6.3"
       },
       "bin": {
         "node-red": "red.js",
@@ -5735,22 +5821,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/node-red/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-watch": {
@@ -6366,32 +6436,19 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
+        "iconv-lite": "0.6.3",
         "unpipe": "1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read": {
@@ -7150,15 +7207,15 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.2.0.tgz",
-      "integrity": "sha512-hctwP0Nb4AB60bj8WQgRYaMOuJYRAPMGiQUAotms5igN8ppfQM+IvjQ5HcKu1MaZh2Wy2KWVTe563Yj8dfc14w==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^7.1.0",
+        "minipass": "^7.1.2",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -7265,22 +7322,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.48",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.48.tgz",
-      "integrity": "sha512-SPbnh1zaSzi/OsmHb1vrPNnYuwJbdWjwo5TbBYYMlTtH3/1DSb41t8bcSxkwDmmbG2q6VLPVvQc7Yf23T+1EEw==",
+      "version": "6.1.56",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.56.tgz",
+      "integrity": "sha512-2PT1oRZCxtsbLi5R2SQjE/v4vvgRggAtVcYj+3Rrcnu2nPZvu7m64+gDa/EsVSWd3QzEc0U0xN+rbEKsJC47kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.48"
+        "tldts-core": "^6.1.56"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.48",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.48.tgz",
-      "integrity": "sha512-3gD9iKn/n2UuFH1uilBviK9gvTNT6iYwdqrj1Vr5mh8FuelvpRNaYVH4pNYqUgOGU4aAdL9X35eLuuj0gRsx+A==",
+      "version": "6.1.56",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.56.tgz",
+      "integrity": "sha512-Ihxv/Bwiyj73icTYVgBUkQ3wstlCglLoegSgl64oSrGUBX1hc7Qmf/CnrnJLaQdZrCnTaLqMYOwKMKlkfkFrxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7341,9 +7398,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -7414,9 +7471,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7459,15 +7516,6 @@
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
-      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
@@ -7839,18 +7887,18 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
-      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@emnapi/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-E7Vgw78I93we4ZWdYCb4DGAwRROGkMIXk7/y87UmANR+J6qsWusmC3gLt0H+O0KOt5e6O38U8oJamgbudrES/w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7859,9 +7907,9 @@
       }
     },
     "@emnapi/runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7879,18 +7927,18 @@
       }
     },
     "@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.2.tgz",
+      "integrity": "sha512-2WwyTYNVaMNUWPZTOJdkax9iqTdirrApgTbk+Qoq5EPX6myqZvG8QGFRgdKmkjKVG6/G/a565vpPauHk0+hpBA==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -7943,13 +7991,13 @@
       "integrity": "sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w=="
     },
     "@firebase/app": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.11.tgz",
-      "integrity": "sha512-DuI8c+p/ndPmV6V0i+mcSuaU9mK9Pi9h76WOYFkPNsbmkblEy8bpTOazjG7tnfar6Of1Wn5ohvyOHSRqnN6flQ==",
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.15.tgz",
+      "integrity": "sha512-he6qlG3pmwL+LHdG/BrSMBQeJzzutciq4fpXN3lGa1uSwYSijJ24VtakS/bP2X9SiDf8jGywJ4u+OgXAenJsNg==",
       "requires": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       }
@@ -7965,15 +8013,14 @@
       "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
     },
     "@firebase/auth": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
-      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.8.0.tgz",
+      "integrity": "sha512-/O7UDWE5S5ux456fzNHSLx/0YN/Kykw/WyAzgDQ6wvkddZhSEmPX19EzxgsFldzhuFjsl5uOZTz8kzlosCiJjg==",
       "requires": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
+        "tslib": "^2.1.0"
       }
     },
     "@firebase/auth-interop-types": {
@@ -7982,24 +8029,24 @@
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
     },
     "@firebase/component": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
-      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.10.tgz",
+      "integrity": "sha512-OsNbEKyz9iLZSmMUhsl6+kCADzte00iisJIRUspnUqvDCX+RSGZOBIqekukv/jN177ovjApBQNFaxSYIDc/SyQ==",
       "requires": {
-        "@firebase/util": "1.10.0",
+        "@firebase/util": "1.10.1",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
-      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.9.tgz",
+      "integrity": "sha512-EkiPSKSu2TJJGtOjyISASf3UFpFJDil1lMbfqnxilfbmIsilvC8DzgjuLoYD+eOitcug4wtU9Fh1tt2vgBhskA==",
       "requires": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
@@ -8015,6 +8062,47 @@
         "@firebase/logger": "0.4.2",
         "@firebase/util": "1.10.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.6.9",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+          "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+          "requires": {
+            "@firebase/util": "1.10.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/database": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+          "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+          "requires": {
+            "@firebase/app-check-interop-types": "0.3.2",
+            "@firebase/auth-interop-types": "0.2.3",
+            "@firebase/component": "0.6.9",
+            "@firebase/logger": "0.4.2",
+            "@firebase/util": "1.10.0",
+            "faye-websocket": "0.11.4",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+          "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+          "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/database-types": {
@@ -8024,54 +8112,63 @@
       "requires": {
         "@firebase/app-types": "0.9.2",
         "@firebase/util": "1.10.0"
+      },
+      "dependencies": {
+        "@firebase/util": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+          "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@firebase/firestore": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.2.tgz",
-      "integrity": "sha512-WPkL/DEHuJg1PZPyHn81pNUhitG+7WkpLVdXmoYB23Za3eoM8VzuIn7zcD4Cji6wDCGA6eI1rvGYLtsXmE1OaQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.4.tgz",
+      "integrity": "sha512-K2nq4w+NF8J1waGawY5OHLawP/Aw5CYxyDstVv1NZemGPcM3U+LZ9EPaXr1PatYIrPA7fS4DxZoWcbB0aGJ8Zg==",
       "requires": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "@firebase/webchannel-wrapper": "1.0.1",
+        "@firebase/component": "0.6.10",
+        "@firebase/logger": "0.4.3",
+        "@firebase/util": "1.10.1",
+        "@firebase/webchannel-wrapper": "1.0.2",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "tslib": "^2.1.0"
       }
     },
     "@firebase/logger": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
-      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.3.tgz",
+      "integrity": "sha512-Th42bWJg18EF5bJwhRosn2M/eYxmbWCwXZr4hHX7ltO0SE3QLrpgiMKeRBR/NW7vJke7i0n3i8esbCW2s93qBw==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@firebase/util": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
-      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.1.tgz",
+      "integrity": "sha512-AIhFnCCjM8FmCqSNlNPTuOk3+gpHC1RkeNUBLtPbcqGYpN5MxI5q7Yby+rxycweOZOCboDzfIj8WyaY4tpQG/g==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
-      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.2.tgz",
+      "integrity": "sha512-3F4iA2E+NtdMbOU0XC1cHE8q6MqpGIKRj62oGOF38S6AAx5VHR9cXmoDUSj7ejvTAT7m6jxuEeQkHeq0F+mU2w=="
     },
     "@gogovega/firebase-config-node": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.1.5.tgz",
-      "integrity": "sha512-Com8lzKwkaIOTw7DhkmEmgdTXou5Rc8qASKztLCj5xF+D7m0cvUrvaI74ymZMAaVV8riL95McqVomoGdZtGJFg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gogovega/firebase-config-node/-/firebase-config-node-0.2.0.tgz",
+      "integrity": "sha512-uKGHhx3I63dO2ajS6OWqFZXfKZAQoGdUuzqPEx/pufvHGyj1K05gzvNZ1coO3cR5FtSXnnDn17iQq66ycEWjEQ==",
       "requires": {
-        "@firebase/app": "0.10.11",
-        "@firebase/auth": "1.7.9",
-        "@firebase/database": "1.0.8",
-        "@firebase/firestore": "4.7.2",
-        "firebase-admin": "^12.5.0",
+        "@firebase/app": "0.10.15",
+        "@firebase/auth": "1.8.0",
+        "@firebase/database": "1.0.9",
+        "@firebase/firestore": "4.7.4",
+        "firebase-admin": "^12.7.0",
         "tiny-typed-emitter": "^2.1.0"
       }
     },
@@ -8286,9 +8383,9 @@
       "optional": true
     },
     "@napi-rs/wasm-runtime": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
-      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.5.tgz",
+      "integrity": "sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8298,20 +8395,20 @@
       }
     },
     "@node-red/editor-api": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-4.0.3.tgz",
-      "integrity": "sha512-neNj/CtCv9gfwWvSY2r/8U259hWrq2yX9t+Pe4lxfCdiBHm0/CUBs8xLHqqz3dBucQNK0ahRxCfBwWhI9AyKhA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-4.0.5.tgz",
+      "integrity": "sha512-X+c/v+HbAjBefqNPiPKA6k7R+MWuYRKB5+n7I23aF+GYEI/ExbbC4A0IXGKVXE0vrdZb1ffAWl0Xx8jldZMJfA==",
       "dev": true,
       "requires": {
-        "@node-red/editor-client": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/editor-client": "4.0.5",
+        "@node-red/util": "4.0.5",
         "@node-rs/bcrypt": "1.10.4",
         "bcryptjs": "2.4.3",
         "body-parser": "1.20.3",
         "clone": "2.1.2",
         "cors": "2.8.5",
-        "express": "4.21.0",
-        "express-session": "1.18.0",
+        "express": "4.21.1",
+        "express-session": "1.18.1",
         "memorystore": "1.6.7",
         "mime": "3.0.0",
         "multer": "1.4.5-lts.1",
@@ -8324,15 +8421,15 @@
       }
     },
     "@node-red/editor-client": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-4.0.3.tgz",
-      "integrity": "sha512-mnfLU6iOUNdzrrHt6XYnVfZPixWrKDOmMfbz+USJR2JgAC25DLuezIIlTgA6FAbNaG3dXAsCN0mCQUw/7nV9cQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-4.0.5.tgz",
+      "integrity": "sha512-ZeM4Nbyg6bCmyWIzKhGjH3VFOmSmuPmFLK7Z7a/8lHY5Qs4fj9GvdWjcjXp+8q030ydVd4WF38PXRMu87GqiaQ==",
       "dev": true
     },
     "@node-red/nodes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-4.0.3.tgz",
-      "integrity": "sha512-bds0KpzTT2QXmTuchekyOLf6H0O44lDfBIcfIZu6CLIPVD6yW+8joXQKBcbfpdPzprDlygIIcBTni1tTgQASwA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-4.0.5.tgz",
+      "integrity": "sha512-YEIt2KK1/2Z/Had23RXcVH2WMD2nZlIRz2Ds981LUBZr6zpSZDEoKwiyBE1Lqnrrs7dwVYNXS7CA1KjdajzLiQ==",
       "dev": true,
       "requires": {
         "acorn": "8.12.1",
@@ -8341,14 +8438,14 @@
         "body-parser": "1.20.3",
         "cheerio": "1.0.0-rc.10",
         "content-type": "1.0.5",
-        "cookie": "0.6.0",
-        "cookie-parser": "1.4.6",
+        "cookie": "0.7.2",
+        "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "cronosjs": "1.7.1",
         "denque": "2.1.0",
         "form-data": "4.0.0",
         "fs-extra": "11.2.0",
-        "got": "12.6.0",
+        "got": "12.6.1",
         "hash-sum": "2.0.0",
         "hpagent": "1.2.0",
         "https-proxy-agent": "5.0.1",
@@ -8361,13 +8458,19 @@
         "mustache": "4.2.0",
         "node-watch": "0.7.4",
         "on-headers": "1.0.2",
-        "raw-body": "2.5.2",
+        "raw-body": "3.0.0",
         "tough-cookie": "^5.0.0",
         "uuid": "9.0.1",
         "ws": "7.5.10",
         "xml2js": "0.6.2"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.12.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+          "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+          "dev": true
+        },
         "agent-base": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -8414,50 +8517,39 @@
       }
     },
     "@node-red/registry": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-4.0.3.tgz",
-      "integrity": "sha512-2+v5MyP4C4cokRGNuBiDZMBd6k8cu3SHMPEt6Cby/CaTk9MlPzEdReAHq5wlzno/0nBTu9fN1ITbRD9Rd+M59w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-4.0.5.tgz",
+      "integrity": "sha512-bAt1gWibjYoIttyi8YPFgWIXNMdNXm1SjGc7Jag7tlDiLrYn0m8MJDO8OyVDp/xzFQ2rePtVZtdoa1SDMhrB2w==",
       "dev": true,
       "requires": {
-        "@node-red/util": "4.0.3",
+        "@node-red/util": "4.0.5",
         "clone": "2.1.2",
         "fs-extra": "11.2.0",
-        "semver": "7.5.4",
-        "tar": "7.2.0",
+        "semver": "7.6.3",
+        "tar": "7.4.3",
         "uglify-js": "3.17.4"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@node-red/runtime": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-4.0.3.tgz",
-      "integrity": "sha512-ftPOkDh9jPLFrxiF3kycKrU61lSjSws1Qv44gEoihvcqwujMIFhuSA14XOXn9St+nPSuaglI8Ud7XShdFtt22g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-4.0.5.tgz",
+      "integrity": "sha512-6CDJsY8zUMn+fzgAEEe+rS/FgQEoMPhNZzS1f4QjGn8uLUSyBfrCwxlHQwRCue/s26IxdMKUr7qqJkqnH7ASxw==",
       "dev": true,
       "requires": {
-        "@node-red/registry": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/registry": "4.0.5",
+        "@node-red/util": "4.0.5",
         "async-mutex": "0.5.0",
         "clone": "2.1.2",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "fs-extra": "11.2.0",
         "json-stringify-safe": "5.0.1",
         "rfdc": "^1.3.1"
       }
     },
     "@node-red/util": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-4.0.3.tgz",
-      "integrity": "sha512-jR+/+luAAxblGDagrKsoh81xfpteofU6LnQxuVTyY2ecJ/JidmtYorlL+UeF479E2+uyZEi/w1fafsTJ09Jokw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-4.0.5.tgz",
+      "integrity": "sha512-g0czs4jKpWPx7auvBbz9MSCEL/f9/xlQMCHTYB2qbV+rouvBQS3ygaUI9Lqx2n9rYbdFm0BKteWVyznP/Vzhvw==",
       "dev": true,
       "requires": {
         "fs-extra": "11.2.0",
@@ -8466,7 +8558,7 @@
         "jsonata": "2.0.5",
         "lodash.clonedeep": "^4.5.0",
         "moment": "2.30.1",
-        "moment-timezone": "0.5.45"
+        "moment-timezone": "0.5.46"
       }
     },
     "@node-rs/bcrypt": {
@@ -8803,9 +8895,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
-      "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.1.tgz",
+      "integrity": "sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -8826,9 +8918,9 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/jquery": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.31.tgz",
-      "integrity": "sha512-rf/iB+cPJ/YZfMwr+FVuQbm7IaWC4y3FVYfVDxRGqmUCFjjPII0HWaP0vTPJGp6m4o13AXySCcMbWfrWtBFAKw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -8854,11 +8946,11 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "version": "22.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
+      "integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
       "requires": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "@types/node-red": {
@@ -8953,9 +9045,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/readable-stream": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
-      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.16.tgz",
+      "integrity": "sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -8983,14 +9075,15 @@
       },
       "dependencies": {
         "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+          "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
           "optional": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "^2.1.12",
+            "safe-buffer": "^5.2.1"
           }
         }
       }
@@ -9015,9 +9108,9 @@
       }
     },
     "@types/sizzle": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
-      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
       "dev": true
     },
     "@types/tough-cookie": {
@@ -9036,16 +9129,16 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
-      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/type-utils": "8.7.0",
-        "@typescript-eslint/utils": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -9053,54 +9146,54 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
-      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/typescript-estree": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
-      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0"
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
-      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "8.7.0",
-        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
-      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
-      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/visitor-keys": "8.7.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -9110,24 +9203,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
-      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.7.0",
-        "@typescript-eslint/types": "8.7.0",
-        "@typescript-eslint/typescript-estree": "8.7.0"
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
-      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/types": "8.11.0",
         "eslint-visitor-keys": "^3.4.3"
       }
     },
@@ -9163,9 +9256,9 @@
       }
     },
     "acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -9416,6 +9509,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
+        },
+        "raw-body": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+          "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
         }
       }
     },
@@ -9701,27 +9806,19 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true
     },
     "cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
       "dev": true,
       "requires": {
-        "cookie": "0.4.1",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-          "dev": true
-        }
       }
     },
     "cookie-signature": {
@@ -10171,9 +10268,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -10181,7 +10278,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -10209,6 +10306,12 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+          "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10227,12 +10330,12 @@
       }
     },
     "express-session": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
-      "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
       "dev": true,
       "requires": {
-        "cookie": "0.6.0",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
         "debug": "2.6.9",
         "depd": "~2.0.0",
@@ -10335,9 +10438,9 @@
       }
     },
     "fast-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true
     },
     "fast-xml-parser": {
@@ -10427,13 +10530,13 @@
       }
     },
     "firebase-admin": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.5.0.tgz",
-      "integrity": "sha512-ad8vnlPcuuZN9scSgY8UnAxPI4mzP2/Q+dsrVLTf+j3h7bIq0FOelDCDGz4StgKJdk244v2kpOxqJjPG3grBHg==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "requires": {
         "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "^1.0.2",
-        "@firebase/database-types": "^1.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0",
         "@types/node": "^22.0.1",
@@ -10501,13 +10604,13 @@
       "dev": true
     },
     "formidable": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
-      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
       "dev": true,
       "requires": {
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
+        "hexoid": "^2.0.0",
         "once": "^1.4.0"
       }
     },
@@ -10657,9 +10760,9 @@
       }
     },
     "google-auth-library": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.1.tgz",
-      "integrity": "sha512-Rj+PMjoNFGFTmtItH7gHfbHpGVSb3vmnGK3nwNBqxQF9NoBpttSZI/rc0WiM63ma2uGDQtYEkMHkK9U6937NiA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
+      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
       "optional": true,
       "requires": {
         "base64-js": "^1.3.0",
@@ -10691,9 +10794,9 @@
       },
       "dependencies": {
         "@grpc/grpc-js": {
-          "version": "1.11.3",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.3.tgz",
-          "integrity": "sha512-i9UraDzFHMR+Iz/MhFLljT+fCpgxZ3O6CxwGJ8YuNYHJItIHUzKJpW2LvoFZNnGPwqc9iWy9RAucxV0JoR9aUQ==",
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz",
+          "integrity": "sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==",
           "optional": true,
           "requires": {
             "@grpc/proto-loader": "^0.7.13",
@@ -10718,9 +10821,9 @@
       }
     },
     "got": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
-      "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^5.2.0",
@@ -10813,9 +10916,9 @@
       "dev": true
     },
     "hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
       "dev": true
     },
     "hpagent": {
@@ -11602,9 +11705,9 @@
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
       "dev": true,
       "requires": {
         "moment": "^2.29.4"
@@ -11816,35 +11919,24 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-red": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/node-red/-/node-red-4.0.3.tgz",
-      "integrity": "sha512-6ZYh54FKqkEANoFgUBNgHm4LaUg5m3eW/01Dslf3cf3aeaRPa9mpS63sRiFC75JuJCxN29LH1/As91/1lSOxYA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/node-red/-/node-red-4.0.5.tgz",
+      "integrity": "sha512-U//K/M/0EJrD80VPGmF+tHoMJVEykBBMgLmKPbKH9m0msXN1O/OC1VpGtyeUAGRwVsNQe0KgFNu6+G4JIguBcA==",
       "dev": true,
       "requires": {
-        "@node-red/editor-api": "4.0.3",
-        "@node-red/nodes": "4.0.3",
-        "@node-red/runtime": "4.0.3",
-        "@node-red/util": "4.0.3",
+        "@node-red/editor-api": "4.0.5",
+        "@node-red/nodes": "4.0.5",
+        "@node-red/runtime": "4.0.5",
+        "@node-red/util": "4.0.5",
         "@node-rs/bcrypt": "1.10.4",
         "basic-auth": "2.0.1",
         "bcryptjs": "2.4.3",
         "cors": "2.8.5",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "fs-extra": "11.2.0",
         "node-red-admin": "^4.0.1",
         "nopt": "5.0.0",
-        "semver": "7.5.4"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "semver": "7.6.3"
       }
     },
     "node-red-admin": {
@@ -12282,26 +12374,15 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
+        "iconv-lite": "0.6.3",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "read": {
@@ -12831,14 +12912,14 @@
       }
     },
     "tar": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.2.0.tgz",
-      "integrity": "sha512-hctwP0Nb4AB60bj8WQgRYaMOuJYRAPMGiQUAotms5igN8ppfQM+IvjQ5HcKu1MaZh2Wy2KWVTe563Yj8dfc14w==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^7.1.0",
+        "minipass": "^7.1.2",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -12910,18 +12991,18 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "tldts": {
-      "version": "6.1.48",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.48.tgz",
-      "integrity": "sha512-SPbnh1zaSzi/OsmHb1vrPNnYuwJbdWjwo5TbBYYMlTtH3/1DSb41t8bcSxkwDmmbG2q6VLPVvQc7Yf23T+1EEw==",
+      "version": "6.1.56",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.56.tgz",
+      "integrity": "sha512-2PT1oRZCxtsbLi5R2SQjE/v4vvgRggAtVcYj+3Rrcnu2nPZvu7m64+gDa/EsVSWd3QzEc0U0xN+rbEKsJC47kA==",
       "dev": true,
       "requires": {
-        "tldts-core": "^6.1.48"
+        "tldts-core": "^6.1.56"
       }
     },
     "tldts-core": {
-      "version": "6.1.48",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.48.tgz",
-      "integrity": "sha512-3gD9iKn/n2UuFH1uilBviK9gvTNT6iYwdqrj1Vr5mh8FuelvpRNaYVH4pNYqUgOGU4aAdL9X35eLuuj0gRsx+A==",
+      "version": "6.1.56",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.56.tgz",
+      "integrity": "sha512-Ihxv/Bwiyj73icTYVgBUkQ3wstlCglLoegSgl64oSrGUBX1hc7Qmf/CnrnJLaQdZrCnTaLqMYOwKMKlkfkFrxQ==",
       "dev": true
     },
     "to-regex-range": {
@@ -12962,9 +13043,9 @@
       "requires": {}
     },
     "tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -13012,9 +13093,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true
     },
     "uglify-js": {
@@ -13037,11 +13118,6 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
       "dev": true
-    },
-    "undici": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
-      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A=="
     },
     "undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Node-RED nodes to communicate with Google Firebase Realtime Databases",
   "main": "build/nodes/load-config.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.6.3"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "files": [
     "build/",

--- a/package.json
+++ b/package.json
@@ -50,18 +50,18 @@
     "version": ">=3"
   },
   "dependencies": {
-    "@gogovega/firebase-config-node": "^0.1.5"
+    "@gogovega/firebase-config-node": "^0.2.0"
   },
   "devDependencies": {
     "@types/node-red": "^1.3.5",
-    "@typescript-eslint/eslint-plugin": "^8.7.0",
-    "@typescript-eslint/parser": "^8.7.0",
+    "@typescript-eslint/eslint-plugin": "^8.11.0",
+    "@typescript-eslint/parser": "^8.11.0",
     "eslint": "^8.57.1",
     "mocha": "^10.7.3",
-    "node-red": "^4.0.3",
+    "node-red": "^4.0.5",
     "node-red-node-test-helper": "^0.3.4",
     "prettier": "^3.3.3",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.3"
   },
   "engines": {
     "node": ">=14"

--- a/src/migration/config-node.ts
+++ b/src/migration/config-node.ts
@@ -23,7 +23,7 @@ import { NodeAPI } from "node-red";
  *
  * @internal
  */
-const requiredVersion = [0, 1, 5];
+const requiredVersion = [0, 2, 0];
 
 /**
  * Cache system to not read files multiple times.


### PR DESCRIPTION
## Breaking Changes

- Set required version of Node.js to >=18

## Changes

- Bump `@gogovega/firebase-config-node` from 0.1.5 to 0.2.0
  - Only don't wait signout for Firestore and add a safety delay
  - Set required version of Node.js to >=18
  - Set required version of Node-RED to >=3