### PR TITLE
Improve the `First flow` tour guide

### DIFF
--- a/resources/first-flow.js
+++ b/resources/first-flow.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+let paletteFilter;
+
 /**
  * First Flow tour guide for creating a Firebase flow in Node-RED.
  *
@@ -24,7 +26,7 @@
 export default {
 	steps: [
 		{
-			titleIcon: "fa fa-map-o",	// TODO: Firebase icon
+			titleIcon: 'firebase"><img src="/icons/@gogovega/node-red-contrib-firebase-realtime-database/firebase.svg',
 			title: {
 				"en-US": "Create your first Firebase flow",
 				"fr": "Créer votre premier flux Firebase"
@@ -44,15 +46,20 @@ export default {
 			},
 			prepare: function (done) {
 				// Show only the Firebase category - to avoid to freeze the workspace
-				// RED.palette doesn't allow this sort of filter so it's a trick 🤫
-				$("#red-ui-palette .red-ui-palette-header").closest(".red-ui-palette-category").hide();
-				$("#red-ui-palette-header-Firebase").closest(".red-ui-palette-category").show();
-				setTimeout(done, 200);
+				// RED.palette doesn't allow to sort by category so it's a trick 🤫
+				const filter = $("#red-ui-palette-search input");
+				paletteFilter = filter.searchBox("value");
+				filter.searchBox("value", "");
+				setTimeout(function () {
+					$("#red-ui-palette .red-ui-palette-header").closest(".red-ui-palette-category").hide();
+					$("#red-ui-palette-header-Firebase").closest(".red-ui-palette-category").show();
+					done();
+				}, 200);
 			},
 			complete: function () {
 				// Clear the Firebase filter to returns to previous Palette state
 				$("#red-ui-palette-search input").searchBox("value", "pending");
-				$("#red-ui-palette-search input").searchBox("value", "");
+				$("#red-ui-palette-search input").searchBox("value", paletteFilter || "");
 			}
 		},
 		{

--- a/resources/first-flow.js
+++ b/resources/first-flow.js
@@ -25,7 +25,7 @@ let paletteFilter;
  */
 export default {
 	steps: [
-		{
+		{	// TODO: go through a class for icon
 			titleIcon: 'firebase"><img src="/icons/@gogovega/node-red-contrib-firebase-realtime-database/firebase.svg',
 			title: {
 				"en-US": "Create your first Firebase flow",
@@ -41,8 +41,8 @@ export default {
 			element: "#red-ui-palette-base-category-Firebase",
 			direction: "right",
 			description: {
-				"en-US": "The Firebase palette lists all of the nodes available to use.",
-				"fr": "La palette Firebase répertorie tous les noeuds disponibles à utiliser."
+				"en-US": "The Firebase palette lists all of the nodes available to use. Lets explore them.",
+				"fr": "La palette Firebase répertorie tous les noeuds disponibles à utiliser. Prenons un moment pour les découvrir."
 			},
 			prepare: function (done) {
 				// Show only the Firebase category - to avoid to freeze the workspace
@@ -55,6 +55,55 @@ export default {
 					$("#red-ui-palette-header-Firebase").closest(".red-ui-palette-category").show();
 					done();
 				}, 200);
+			}
+		},
+		{
+			element: ".red-ui-palette-node[data-palette-type='firebase-in']",
+			direction: "right",
+			title: {
+				"en-US": "The Firebase In Node",
+				"fr": "Le noeud Firebase In"
+			},
+			description: {
+				"en-US": "This node subscribes to data at the specified path and sends a payload for each change.",
+				"fr": "Ce noeud s'abonne aux données du chemin spécifié et envoie une charge utile pour chaque changement."
+			}
+		},
+		{
+			element: ".red-ui-palette-node[data-palette-type='firebase-get']",
+			direction: "right",
+			title: {
+				"en-US": "The Firebase Get Node",
+				"fr": "Le noeud Firebase Get"
+			},
+			description: {
+				"en-US": "This node reads the data from the specified path and sends a payload.",
+				"fr": "Ce noeud lit les données du chemin spécifié et envoie une charge utile."
+			}
+		},
+		{
+			element: ".red-ui-palette-node[data-palette-type='firebase-out']",
+			direction: "right",
+			title: {
+				"en-US": "The Firebase Out Node",
+				"fr": "Le noeud Firebase Out"
+			},
+			description: {
+				"en-US": "This node modifies the data at the specified path.",
+				"fr": "Ce noeud modifie les données du chemin spécifié."
+			}
+		},
+		{
+			element: ".red-ui-palette-node[data-palette-type='on-disconnect']",
+			direction: "right",
+			width: 400,
+			title: {
+				"en-US": "The On-Disconnect Node",
+				"fr": "Le noeud On-Disconnect"
+			},
+			description: {
+				"en-US": "This node modifies the data at the specified path only when a connection loss occurs between Node-RED and Firebase.",
+				"fr": "Ce noeud modifie les données du chemin spécifié uniquement lors d'une perte de connexion entre Node-RED et Firebase."
 			},
 			complete: function () {
 				// Clear the Firebase filter to returns to previous Palette state
@@ -65,9 +114,14 @@ export default {
 		{
 			element: "#red-ui-tab-red-ui-clipboard-dialog-import-tab-examples",
 			direction: "bottom",
+			width: 400,
+			title: {
+				"en-US": "Let's import a flow of examples",
+				"fr": "Importons un flux d'exemples"
+			},
 			description: {
-				"en-US": "<p>Let's import a flow of examples. Click on the '<strong>Examples</strong>' button.</p>",
-				"fr": "<p>Importons un flux d'exemples. Cliquer sur le bouton '<strong>Exemples</strong>'.</p>"
+				"en-US": "<p>Click on the '<strong>Examples</strong>' button.</p>",
+				"fr": "<p>Cliquer sur le bouton '<strong>Exemples</strong>'.</p>"
 			},
 			fallback: "inset-bottom-right",
 			wait: {

--- a/resources/migration.js
+++ b/resources/migration.js
@@ -450,8 +450,15 @@
 					$.fn.remove = originalRemove;
 				}
 
-				RED.tourGuide.run(`/resources/@${packageName}/${tourName}.js`, function(error) {
-					if (error) console.error("Firebase: ", error);
+				// TODO: At this stage, it's better to load the file from the repo
+				// to avoid publishing a new version for every change made to the tour.
+				const url = "https://cdn.jsdelivr.net/gh/GogoVega/node-red-contrib-firebase-realtime-database@master/resources/first-flow.js";
+				RED.tourGuide.run(url/*`/resources/@${packageName}/${tourName}.js`*/, function(error) {
+					if (error) {
+						console.error("Firebase tour: ", error);
+						RED.notify("Failed to load the Firebase tour", "error");
+					}
+
 					RED.settings.set(settingName, true);
 				});
 			} else if (tourRunning) {


### PR DESCRIPTION
Introduced by #79, the following improvements have been made:

- Prevents the tour from starting while another tour is in progress. (not yet protected into the core)
- Fixes restoration of previously applied palette filter.
- Adds the Firebase icon.
- Adds one step per node to describe it.

Also, for this phase of development, the tour will be loaded from the repo to avoid publishing a new version for each change made.

**As a reminder**: this feature is a demonstrator - it is not currently designed to be used by third-party node developers. If you like it, please let the NR team know so that it can be opened up.