### PR TITLE
Offers all types to the `Path` field by default

### DIFF
--- a/build/nodes/firebase-in.html
+++ b/build/nodes/firebase-in.html
@@ -59,16 +59,23 @@
 				editableConstraintsList.build(this);
 
 				const pathField = typedPathField.create().allowBlank(true).enableAutoComplete();
-				const listenerType = $("#node-input-listenerType");
 
 				pathField.build();
-
-				listenerType.on("change", () => pathField.switchModeToStaticOrDynamic(listenerType.val() !== "none"));
 			},
 			oneditsave: function () {
 				editableConstraintsList.saveItems();
 
-				const inputs = $("#node-input-listenerType").val() === "none" ? 1 : 0;
+				const isDynamic = function (type = "str", value) {
+					return type === "msg" ? true : (type !== "str" && type !== "env")
+						? /\[msg/.test(value ?? "")
+						: false;
+				};
+
+				const path = $("#node-input-path");
+				const listenerDynamic = $("#node-input-listenerType").val() === "none";
+				const pathDynamic = isDynamic(path.typedInput("type"), path.typedInput("value"));
+				const constraintDynamic = Object.values(this.constraints).some((v) => isDynamic(v?.type ?? v?.types?.child ?? v?.types?.value, v?.value ?? v?.key));
+				const inputs = (listenerDynamic || pathDynamic || constraintDynamic) ? 1 : 0;
 				$("#node-input-inputs").val(inputs);
 			},
 			oneditresize: (size) => editableConstraintsList.reSize(size),

--- a/src/lib/firebase-node.ts
+++ b/src/lib/firebase-node.ts
@@ -538,12 +538,20 @@ export class FirebaseGet extends Firebase<FirebaseGetNode> {
  */
 export class FirebaseIn extends Firebase<FirebaseInNode> {
 	/**
+	 * Whether the node should await a payload to subscribe to data.
+	 */
+	private isDynamicConfig: boolean = false;
+
+	/**
 	 * This property contains the **method to call** to unsubscribe the listener
 	 */
 	private unsubscribeCallback?: Unsubscribe;
 
 	constructor(node: FirebaseInNode, config: FirebaseInConfig, RED: NodeAPI) {
 		super(node, config, RED);
+
+		// No need to re-check all config - if the node has an input, the config is dynamic.
+		this.isDynamicConfig = this.node.config.inputs === 1;
 	}
 
 	/**
@@ -575,7 +583,7 @@ export class FirebaseIn extends Firebase<FirebaseInNode> {
 				const listener = this.getListener(msg);
 
 				// Await the listener defined in the incoming message
-				if (listener === "none" || (this.node.config.inputs === 1 && !msg)) return;
+				if (listener === "none" || (this.isDynamicConfig && !msg)) return;
 
 				const path = await this.getPath(msg, true);
 				const constraints = await this.getQueryConstraints(msg);

--- a/src/lib/types/firebase-config.ts
+++ b/src/lib/types/firebase-config.ts
@@ -108,6 +108,7 @@ export type FirebaseInConfig = BaseConfig & {
 	 */
 	constraint?: QueryConstraint;
 	constraints?: QueryConstraint;
+	inputs?: 0 | 1;
 	listenerType?: ListenerType;
 	outputType?: OutputType;
 	passThrough?: boolean;


### PR DESCRIPTION
If a user wants to use the `env` type of the `Path` field he must set the listener to `use msg.listener` which prevents the listener from being static.

To solve this, all types of the `Path` field are available by default and the node input will be present depending on listener, path and constraints settings.