### PR TITLE
Mark select input as error if constraint already used

### DIFF
--- a/build/nodes/locales/en-US/load-config.json
+++ b/build/nodes/locales/en-US/load-config.json
@@ -36,7 +36,8 @@
       "invalid-type-prop": "__prop__: The type of property __prop__ is not or no longer valid, please select a valid type",
       "no-integer": "The value of the defined property must be an integer",
       "no-integer-prop": "__prop__: The value of the defined __prop__ property must be an integer",
-      "no-object": "The value of the defined property must be an object"
+      "no-object": "The value of the defined property must be an object",
+      "type-in-use": "This type of constraint is already used"
     }
   }
 }

--- a/build/nodes/locales/en-US/load-config.json
+++ b/build/nodes/locales/en-US/load-config.json
@@ -34,6 +34,8 @@
       "invalid-range-prop": "__prop__: The value of the __prop__ property defined is not in a valid range",
       "invalid-type": "The selected type is not or no longer valid, please select a valid type",
       "invalid-type-prop": "__prop__: The type of property __prop__ is not or no longer valid, please select a valid type",
+      "multiple-limit": "Only one constraint of type 'Limit to...' is allowed",
+      "multiple-order": "Only one constraint of type 'Order by...' is allowed",
       "no-integer": "The value of the defined property must be an integer",
       "no-integer-prop": "__prop__: The value of the defined __prop__ property must be an integer",
       "no-object": "The value of the defined property must be an object",

--- a/build/nodes/locales/fr/load-config.json
+++ b/build/nodes/locales/fr/load-config.json
@@ -36,7 +36,8 @@
       "invalid-type-prop": "__prop__ : Le type de la propriété __prop__ n'est pas ou plus valide, veuillez sélectionner un type valide",
       "no-integer": "La valeur de la propriété définie doit être un entier",
       "no-integer-prop": "__prop__ : La valeur de la propriété __prop__ définie doit être un entier",
-      "no-object": "La valeur de la propriété définie doit être un objet"
+      "no-object": "La valeur de la propriété définie doit être un objet",
+      "type-in-use": "Ce type de contrainte est déjà utilisé"
     }
   }
 }

--- a/build/nodes/locales/fr/load-config.json
+++ b/build/nodes/locales/fr/load-config.json
@@ -34,6 +34,8 @@
       "invalid-range-prop": "__prop__ : La valeur de la propriété __prop__ définie n'est pas dans une plage valide",
       "invalid-type": "Le type sélectionné n'est pas ou plus valide, veuillez sélectionner un type valide",
       "invalid-type-prop": "__prop__ : Le type de la propriété __prop__ n'est pas ou plus valide, veuillez sélectionner un type valide",
+      "multiple-limit": "Seule une contrainte de type 'Limiter aux...' est autorisée",
+      "multiple-order": "Seule une contrainte de type 'Trier par...' est autorisée",
       "no-integer": "La valeur de la propriété définie doit être un entier",
       "no-integer-prop": "__prop__ : La valeur de la propriété __prop__ définie doit être un entier",
       "no-object": "La valeur de la propriété définie doit être un objet",

--- a/resources/constraints-container.js
+++ b/resources/constraints-container.js
@@ -189,6 +189,13 @@ var FirebaseQueryConstraintsContainer = FirebaseQueryConstraintsContainer || (fu
 						constraintUsedTypes.delete(previousValue);
 						if (constraintUsedTypes.has(value))
 							return opt ? FirebaseUI._("errors.type-in-use", "load-config", "validator") : false;
+						if (/^(limitTo|orderBy)/.test(value)) {
+							const delim = value.substring(0, 7);
+							for (const type of constraintUsedTypes) {
+								if (type.startsWith(delim))
+									return opt ? FirebaseUI._(`errors.multiple-${value.substring(0, 5)}`, "load-config", "validator") : false;
+							}
+						}
 						constraintUsedTypes.add(value);
 						previousValue = value;
 						return true;

--- a/resources/constraints-container.js
+++ b/resources/constraints-container.js
@@ -34,6 +34,8 @@ var FirebaseQueryConstraintsContainer = FirebaseQueryConstraintsContainer || (fu
 	const limitFieldTypes = [{ value: "num", label: "number", icon: "red/images/typedInput/09.svg", validate: FirebaseUI.validators.priority() }, ...dynamicFieldTypes];
 	const rangeFieldTypes = ["bool", "num", "str", "date", { value: "null", label: "null", hasValue: false }, ...dynamicFieldTypes];
 
+	const constraintUsedTypes = new Set();
+
 	class EditableQueryConstraintsList {
 		constructor() {
 			this.containerId = "#node-input-constraints-container";
@@ -77,6 +79,7 @@ var FirebaseQueryConstraintsContainer = FirebaseQueryConstraintsContainer || (fu
 			} else {
 				this.containerRow?.hide();
 				this.container?.editableList("empty");
+				constraintUsedTypes.clear();
 			}
 
 			RED.tray.resize();
@@ -147,6 +150,8 @@ var FirebaseQueryConstraintsContainer = FirebaseQueryConstraintsContainer || (fu
 						break;
 				}
 			});
+
+			constraintUsedTypes.clear();
 		}
 	}
 
@@ -175,8 +180,21 @@ var FirebaseQueryConstraintsContainer = FirebaseQueryConstraintsContainer || (fu
 			})
 			.typedInput("hide");
 
+		let previousValue;
 		constraintType
-			.typedInput({ types: [{ options: queryConstraintFieldOptions }] })
+			.typedInput({ type: "constraint", types: [{
+					value: "constraint",
+					options: queryConstraintFieldOptions,
+					validate: function (value, opt) {	// Missing tooltip NR#5051
+						constraintUsedTypes.delete(previousValue);
+						if (constraintUsedTypes.has(value))
+							return opt ? FirebaseUI._("errors.type-in-use", "load-config", "validator") : false;
+						constraintUsedTypes.add(value);
+						previousValue = value;
+						return true;
+					}
+				}]
+			})
 			.on("change", (_event, _type, value) => updateTypeOfTypedInput(valueField, row3, childField, value))
 			.typedInput("value", "orderByValue");
 


### PR DESCRIPTION
Avoid defining the same constraint twice by marking the select input as invalid.

- Same constraint used

<img width="477" alt="Capture d’écran 2025-02-14 à 17 43 19" src="https://github.com/user-attachments/assets/c65a96e9-1fe6-4c31-9935-0207d367f69f" />

- Same type used

<img width="493" alt="Capture d’écran 2025-02-15 à 11 45 47" src="https://github.com/user-attachments/assets/d8c39494-e73e-4869-bbaa-929db75950ce" />

---
> [!NOTE]
> Need Node-RED `4.0.9` to show the tooltip.