### PR TITLE
0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change log
 
+## 0.7.3
+
+### Changes
+
+- (Firebase IN) Offers all types to the `Path` field by default (#83)
+- Bump `@gogovega/firebase-config-node` from 0.2.1 to 0.2.2
+  - Allow UI to set the RTDB `defaultWriteSizeLimit` setting ([#18](https://github.com/GogoVega/Firebase-Config-Node/pull/18))
+
+### Enhances
+
+- (Query Constraint) Mark select input as error if constraint already used (#85)
+- Allow `msg.listener` to unsubscribe from data (#86)
+- Add new node statuses to improve tracking (#87)
+- Improve the node status and add Waiting status (#88)
+
+### Improves
+
+- Avoid Node Messaging timeout (#84)
+- Slight cleanup and move some Firebase class properties to static
+
 ## 0.7.2
 
 ### Changes
@@ -18,7 +38,7 @@
   - Do not call `signout` if app initialization failed ([#15](https://github.com/GogoVega/Firebase-Config-Node/pull/15))
   - Fix bad `Query` object returned by `applyQueryConstraints` ([#16](https://github.com/GogoVega/Firebase-Config-Node/pull/16))
 
-### New Features
+### Enhances
 
 - Introduce the `First flow` tour guide (#79)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@gogovega/firebase-config-node": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gogovega/node-red-contrib-firebase-realtime-database",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Node-RED nodes to communicate with Google Firebase Realtime Databases",
   "main": "build/nodes/load-config.js",
   "scripts": {

--- a/src/migration/config-node.ts
+++ b/src/migration/config-node.ts
@@ -23,7 +23,7 @@ import { NodeAPI } from "node-red";
  *
  * @internal
  */
-const requiredVersion = [0, 2, 1];
+const requiredVersion = [0, 2, 2];
 
 /**
  * Cache system to not read files multiple times.


### PR DESCRIPTION
## Changes

- (Firebase IN) Offers all types to the `Path` field by default
- Bump `@gogovega/firebase-config-node` from 0.2.1 to 0.2.2
  - Allow UI to set the RTDB `defaultWriteSizeLimit` setting

## Enhances

- (Query Constraint) Mark select input as error if constraint already used
- Allow `msg.listener` to unsubscribe from data
- Add new node statuses to improve tracking
- Improve the node status and add Waiting status

## Improves

- Avoid Node Messaging timeout
- Slight cleanup and move some Firebase class properties to static